### PR TITLE
Allow invitations to also use the "update" form

### DIFF
--- a/Civi/RemoteParticipant/Event/GetCancelParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCancelParticipantFormEvent.php
@@ -30,10 +30,10 @@ class GetCancelParticipantFormEvent extends GetParticipantFormEventBase
     /**
      * Get the token usage key for this event type
      *
-     * @return string
+     * @return array
      */
-    protected function getTokenUsage()
+    protected function getTokenUsages()
     {
-        return 'cancel';
+        return ['cancel'];
     }
 }

--- a/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
@@ -74,10 +74,10 @@ class GetCreateParticipantFormEvent extends GetParticipantFormEventBase
     /**
      * Get the token usage key for this event type
      *
-     * @return string
+     * @return array
      */
-    protected function getTokenUsage()
+    protected function getTokenUsages()
     {
-        return 'invite';
+        return ['invite'];
     }
 }

--- a/Civi/RemoteParticipant/Event/GetParticipantFormEventBase.php
+++ b/Civi/RemoteParticipant/Event/GetParticipantFormEventBase.php
@@ -41,15 +41,15 @@ abstract class GetParticipantFormEventBase extends RemoteEvent
         $this->result = [];
         $this->contact_id = null;
         $this->participant_id = null;
-        $this->token_usages = [$this->getTokenUsage()];
+        $this->token_usages = $this->getTokenUsages();
     }
 
     /**
      * Get the token usage key for this event type
      *
-     * @return string
+     * @return array
      */
-    abstract protected function getTokenUsage();
+    abstract protected function getTokenUsages();
 
     /**
      * Returns the original parameters that were submitted to RemoteEvent.get
@@ -87,11 +87,15 @@ abstract class GetParticipantFormEventBase extends RemoteEvent
 
                 } else {
                     // see if there is contact token, use that
-                    $contact_id = \CRM_Remotetools_SecureToken::decodeEntityToken(
-                        'Contact',
-                        $this->params['token'],
-                        $this->getTokenUsage()
-                    );
+                    foreach ($this->getTokenUsages() as $usage) {
+                        if ($contact_id = \CRM_Remotetools_SecureToken::decodeEntityToken(
+                            'Contact',
+                            $this->params['token'],
+                            $usage
+                        )) {
+                            break;
+                        }
+                    }
                     if ($contact_id) {
                         $this->setContactID($contact_id);
                     }

--- a/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
@@ -16,6 +16,8 @@
 
 namespace Civi\RemoteParticipant\Event;
 
+use CRM_Remoteevent_ExtensionUtil as E;
+
 /**
  * Class GetUpdateParticipantFormEvent
  *
@@ -27,12 +29,59 @@ namespace Civi\RemoteParticipant\Event;
 class GetUpdateParticipantFormEvent extends GetParticipantFormEventBase
 {
     /**
+     * GetUpdateParticipantFormEvent constructor.
+     */
+    public function __construct($params, $event)
+    {
+        parent::__construct($params, $event);
+
+        // add 'confirm' field if there already is a participant
+        $participant_id = $this->getParticipantID();
+        if ($participant_id) {
+            try {
+                // check if the participant in status 'Invited'
+                $participant_status_id = (int)\civicrm_api3('Participant', 'getvalue', [
+                    'id' => $participant_id,
+                    'return' => 'participant_status_id',
+                ]);
+                $status_name = \CRM_Remoteevent_Registration::getParticipantStatusName($participant_status_id);
+                if ($status_name == 'Invited') {
+                    // this IS an invitation
+                    $l10n = $this->getLocalisation();
+                    $this->addFields(
+                        [
+                            'confirm' => [
+                                'name' => 'confirm',
+                                'type' => 'Select',
+                                'options' => [
+                                    1 => $l10n->localise('Accept Invitation'),
+                                    0 => $l10n->localise('Decline Invitation'),
+                                ],
+                                'validation' => '',
+                                'weight' => 10,
+                                'required' => 0,
+                                'label' => $l10n->localise('Invitation Feedback'),
+                            ],
+                        ]
+                    );
+                } else {
+                    // todo: there IS a participant, and it's NOT an invite. anything to do here?
+
+                }
+            } catch (\CiviCRM_API3_Exception $ex) {
+                // the participant probably doesn't exist:
+                $this->addWarning(E::ts("The link or reference you're using is no longer valid."));
+            }
+        }
+    }
+
+    /**
      * Get the token usage key for this event type
      *
-     * @return string
+     * @return array
      */
-    protected function getTokenUsage()
+    protected function getTokenUsages()
     {
-        return 'update';
+        return ['update', 'invite'];
     }
 }

--- a/Civi/RemoteParticipant/Event/UpdateEvent.php
+++ b/Civi/RemoteParticipant/Event/UpdateEvent.php
@@ -46,7 +46,7 @@ class UpdateEvent extends ChangingEvent
     public function __construct($submission_data)
     {
         $this->submission = $submission_data;
-        $this->token_usages = ['update'];
+        $this->token_usages = ['update', 'invite'];
     }
 
     /**

--- a/api/v3/RemoteParticipant/GetForm.php
+++ b/api/v3/RemoteParticipant/GetForm.php
@@ -95,11 +95,19 @@ function civicrm_api3_remote_participant_get_form($params)
     if (!empty($params['token'])) {
         // identify event via participant
         $usage_map = [
-                'create' => 'invite',
-                'cancel' => 'cancel',
-                'update' => 'update'];
-
-        $participant_id = CRM_Remotetools_SecureToken::decodeEntityToken('Participant', trim($params['token']), $usage_map[$params['context']]);
+            'create' => ['invite'],
+            'update' => ['update', 'invite'],
+            'cancel' => ['cancel'],
+        ];
+        foreach ($usage_map[$params['context']] as $context) {
+            if ($participant_id = CRM_Remotetools_SecureToken::decodeEntityToken(
+                'Participant',
+                trim($params['token']),
+                $context
+            )) {
+                break;
+            }
+        }
         if (empty($participant_id)) {
             // token is invalid
             if (empty($params['event_id'])) {

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -149,6 +149,9 @@ function remoteevent_civicrm_config(&$config)
         ['CRM_Remoteevent_RegistrationUpdate', 'updateContact'], CRM_Remoteevent_RegistrationUpdate::STAGE2_APPLY_CONTACT_CHANGES);
     $dispatcher->addUniqueListener(
         'civi.remoteevent.registration.update',
+        ['CRM_Remoteevent_Registration', 'confirmExistingParticipant'], CRM_Remoteevent_RegistrationUpdate::STAGE3_APPLY_PARTICIPANT_CHANGES + 20);
+    $dispatcher->addUniqueListener(
+        'civi.remoteevent.registration.update',
         ['CRM_Remoteevent_RegistrationUpdate', 'updateParticipant'], CRM_Remoteevent_RegistrationUpdate::STAGE3_APPLY_PARTICIPANT_CHANGES);
     $dispatcher->addUniqueListener(
         'civi.remoteevent.registration.update',


### PR DESCRIPTION
Confirming/rejecting participant invitations are only working when using the `RemoteParticipant.create` API (with invitation tokens), not with `RemoteParticipant.update`, while it technically is an update.

Also, confirming/rejecting invitations is not possible when the contact has no permission to register (anymore), e.g. because the registration period has expired or the event is locked for new registrations, while invitations should still be processed.

This PR allows invitation confirmation front-ends to use both API endpoints for processing invitations.

Technical details:
* The `RemoteParticipant.get_form` API now adds the *Confirm*/*Reject* field for the `update` context
* All involved APIs now check the token for all allowed contexts (`invite` and `update` for the `update` API)
* The `civi.remoteevent.registration.update` event is now being implemented by `CRM_Remoteevent_Registration::confirmExistingParticipant()` for processing invitations

This does not touch `de.systopia.remotetools` for validating tokens and checks them multiple times if needed instead. Passing multiple contexts into `\CRM_Remotetools_SecureToken::decodeEntityToken()` would be better though, but would add a specific version requirement for that extension.

We should definitely add documentation on that once it's in.