### PR TITLE
[EKIR PHASE II] #20024

### DIFF
--- a/templates/CRM/Remoteevent/Form/EventSessions.tpl
+++ b/templates/CRM/Remoteevent/Form/EventSessions.tpl
@@ -34,7 +34,7 @@
 {foreach from=$sessions key=day item=day_sessions}
   <thead>
   <tr>
-    <th class="header-dark" colspan="100%">{$day}</th>
+    <th class="column-header" colspan="100%">{$day}</th>
   </tr>
   <tr>
     <th></th>


### PR DESCRIPTION
edit EventSessions.tpl
- change css-class of thead`s first row

the theme "Shoreditch" is overwriting <th> elements like this with a white background, which results in white text being invisible.
I therefor suggest to use a base-css-class with non-white font-color like "column-header".