### PR TITLE
Define "confirm" field for event invitations with lower weight and as required

### DIFF
--- a/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
@@ -53,8 +53,8 @@ class GetCreateParticipantFormEvent extends GetParticipantFormEventBase
                              'options'     => [1 => $l10n->localise('Accept Invitation'),
                                                0 => $l10n->localise('Decline Invitation')],
                              'validation'  => '',
-                             'weight'      => 10,
-                             'required'    => 0,
+                             'weight'      => -10,
+                             'required'    => 1,
                              'label'       => $l10n->localise('Invitation Feedback'),
                          ],
                      ]);

--- a/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
@@ -58,8 +58,8 @@ class GetUpdateParticipantFormEvent extends GetParticipantFormEventBase
                                     0 => $l10n->localise('Decline Invitation'),
                                 ],
                                 'validation' => '',
-                                'weight' => 10,
-                                'required' => 0,
+                                'weight' => -10,
+                                'required' => 1,
                                 'label' => $l10n->localise('Invitation Feedback'),
                             ],
                         ]


### PR DESCRIPTION
This fixes issues with the *Accept Invitation* field not being the first field in the form when there are fields with lower weights (i.e. lower than ist current weight of `10`). This is especially the case when using the [remoteeventformeditor](https://github.com/systopia/remoteeventformeditor) extension for defining profile fields.

Also, this field should be required for not showing a *- Select -* option.

Special eye should be kept on whether the now negative weight of `-10` is handled correctly.

*systopia-reference: 22749*