### PR TITLE
Add `has_active_waitlist` flag to events

### DIFF
--- a/CRM/Remoteevent/EventFlags.php
+++ b/CRM/Remoteevent/EventFlags.php
@@ -29,6 +29,7 @@ class CRM_Remoteevent_EventFlags
         'can_edit_registration',
         'can_cancel_registration',
         'is_registered',
+        'has_active_waitlist',
     ];
 
     /** @var string[] list of flags in the event configuration relevant for the UI (full name => internal name) */
@@ -165,6 +166,9 @@ class CRM_Remoteevent_EventFlags
                         self::restrictToContactsEvents($contact_id, $get_parameters);
                     }
                 }
+
+              // TODO: Restrict to events with active waitlist when "has_active_waitlist" is given, for both,
+              //       registration and update.
             }
         }
     }
@@ -194,6 +198,11 @@ class CRM_Remoteevent_EventFlags
             $event['can_instant_register'] = (int)
                    ($event['can_register'] &&
                    CRM_Remoteevent_Registration::canOneClickRegister($event['id'], $event));
+
+            $event['has_active_waitlist'] = (int) (
+                    $event['can_register']
+                    && CRM_Remoteevent_RemoteEvent::hasActiveWaitingList($event['id'], $event)
+            );
 
             // add generic can_edit_registration/can_cancel_registration (might be overridden below)
             $cant_edit_reason = CRM_Remoteevent_Registration::cannotEditRegistration($event['id'], $contact_id, $event);

--- a/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
@@ -83,6 +83,10 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase
         $registration1 = $this->registerRemote($event['id'], ['email' => $contactA['email']]);
         $this->assertEmpty($registration1['is_error'], "First Registration Failed");
 
+        // Retrieve the event.
+        $eventRetrieved = $this->getRemoteEvent($event['id']);
+        $this->assertNotEmpty($eventRetrieved['has_active_waitlist'], 'The flag "has_active_waitlist" should have the value "1".');
+
         // register another contact:
         $contactB = $this->createContact();
         $registration2 = $this->registerRemote($event['id'], ['email' => $contactB['email']]);


### PR DESCRIPTION
There's already a `can_register` flag, which supposedly returns `1` for events that are fully booked but have a waiting list, which events also have a flag for, `has_waitlist`. But there's no flag indicating whether the waiting list is active (i.e. the event is fully booked and new participants are to be added to the waitlist).

* [x] There should be a flag on events for allowing the consuming system to e.g. alter button captions for registration depending on whether new participants will be added to a waiting list or not. This flag should be called `has_active_waitlist`.
* [ ] I'd also vote for adding a filter for this flag, as it is easily query-able.

@bjendres would you be able to line out what else needs to be done for this, apart from what I drafted?

*systopia-reference: 22809*