### PR TITLE
Use class constants for event names

### DIFF
--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -16,6 +16,7 @@
 use CRM_Remoteevent_ExtensionUtil as E;
 use \Civi\RemoteParticipant\Event\RegistrationEvent as RegistrationEvent;
 use \Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent as GetCreateParticipantFormEvent;
+use Civi\RemoteParticipant\Event\UpdateParticipantEvent;
 
 /**
  * Class to execute event registrations (RemoteParticipant.create)
@@ -716,9 +717,9 @@ class CRM_Remoteevent_Registration
         }
 
         // Modify Participant Data Event here. This can be used to maybe manually update/set participant data
-        $update_participant_event = new \Civi\RemoteParticipant\Event\UpdateParticipantEvent($participant_data);
+        $update_participant_event = new UpdateParticipantEvent($participant_data);
         // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
-        Civi::dispatcher()->dispatch(\Civi\RemoteParticipant\Event\UpdateParticipantEvent::NAME, $update_participant_event);
+        Civi::dispatcher()->dispatch(UpdateParticipantEvent::NAME, $update_participant_event);
         $participant_data = $update_participant_event->get_participant_data();
 
         // run create/update

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -19,6 +19,7 @@ use Civi\RemoteEvent as RemoteEvent;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteParticipant\Event\ValidateEvent as ValidateEvent;
 use Civi\RemoteParticipant\Event\RegistrationEvent as RegistrationEvent;
+use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 
 
 /**
@@ -274,9 +275,9 @@ abstract class CRM_Remoteevent_RegistrationProfile
      */
     public static function getRegistrationProfile($profile_name)
     {
-        $profile_list = new RemoteEvent\Event\RegistrationProfileListEvent();
+        $profile_list = new RegistrationProfileListEvent();
         // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
-        Civi::dispatcher()->dispatch('civi.remoteevent.registration.profile.list', $profile_list);
+        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $profile_list);
 
         return $profile_list->getProfileInstance($profile_name);
     }
@@ -289,9 +290,9 @@ abstract class CRM_Remoteevent_RegistrationProfile
      */
     public static function getAvailableRegistrationProfiles()
     {
-        $remote_event_profiles = new RemoteEvent\Event\RegistrationProfileListEvent();
+        $remote_event_profiles = new RegistrationProfileListEvent();
         // Collect Profiles via Symfony Event
-        Civi::dispatcher()->dispatch('civi.remoteevent.registration.profile.list', $remote_event_profiles);
+        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $remote_event_profiles);
 
         $profiles = [];
         foreach ($remote_event_profiles->getProfiles() as $profile) {
@@ -302,12 +303,12 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
 
     /**
-     * @param \Civi\RemoteEvent\Event\RegistrationProfileListEvent $registration_profile_list_event
+     * @param RegistrationProfileListEvent $registration_profile_list_event
      *
      * @return void
      */
     public static function addOptionValueProfiles(
-        RemoteEvent\Event\RegistrationProfileListEvent $registration_profile_list_event)
+        RegistrationProfileListEvent $registration_profile_list_event)
     {
         // TODO: Do we use API4?
         $profile_data = civicrm_api3(

--- a/Civi/LabelEvent.php
+++ b/Civi/LabelEvent.php
@@ -27,7 +27,7 @@ use \Symfony\Contracts\EventDispatcher\Event;
  */
 class LabelEvent extends Event
 {
-    const EVENT_NAME = 'civi.remoteevent.label';
+    const NAME = 'civi.remoteevent.label';
 
     /**
      * @var string context for adjusting the session group header, e.g. "Day 1"
@@ -169,7 +169,7 @@ class LabelEvent extends Event
     public static function renderLabel($original_label, $context, $context_data = [])
     {
         $label_event = new LabelEvent($original_label, $context, $context_data);
-        \Civi::dispatcher()->dispatch(self::EVENT_NAME, $label_event);
+        \Civi::dispatcher()->dispatch(self::NAME, $label_event);
         return $label_event->getLabel();
     }
 }

--- a/Civi/RemoteEvent/Event/GetFieldsEvent.php
+++ b/Civi/RemoteEvent/Event/GetFieldsEvent.php
@@ -26,6 +26,8 @@ use Civi\RemoteEvent;
  */
 class GetFieldsEvent extends RemoteEvent
 {
+    const NAME = 'civi.remoteevent.getfields';
+
     /** @var array holds the list of the RemoteEvent.get field specs */
     protected $field_specs;
 

--- a/Civi/RemoteEvent/Event/GetParamsEvent.php
+++ b/Civi/RemoteEvent/Event/GetParamsEvent.php
@@ -26,6 +26,8 @@ use Civi\RemoteParamsEvent;
  */
 class GetParamsEvent extends RemoteParamsEvent
 {
+    const NAME = 'civi.remoteevent.get.params';
+
     public function __construct($params)
     {
         parent::__construct($params);

--- a/Civi/RemoteEvent/Event/GetResultEvent.php
+++ b/Civi/RemoteEvent/Event/GetResultEvent.php
@@ -27,6 +27,7 @@ use Civi\RemoteEvent;
  */
 class GetResultEvent extends RemoteEvent
 {
+    const NAME = 'civi.remoteevent.get.result';
 
     /** @var array holds the original RemoteEvent.get parameters */
     protected $original_params;

--- a/Civi/RemoteEvent/Event/SpawnParamsEvent.php
+++ b/Civi/RemoteEvent/Event/SpawnParamsEvent.php
@@ -26,5 +26,5 @@ use Civi\RemoteParamsEvent;
  */
 class SpawnParamsEvent extends RemoteParamsEvent
 {
-
+    const NAME = 'civi.remoteevent.spawn.params';
 }

--- a/Civi/RemoteParticipant/Event/CancelEvent.php
+++ b/Civi/RemoteParticipant/Event/CancelEvent.php
@@ -27,6 +27,8 @@ use Civi\RemoteEvent;
  */
 class CancelEvent extends ChangingEvent
 {
+    const NAME = 'civi.remoteevent.registration.cancel';
+
     /** @var array holds the original RemoteParticipant.submit data */
     protected $submission;
 

--- a/Civi/RemoteParticipant/Event/GetCancelParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCancelParticipantFormEvent.php
@@ -27,6 +27,8 @@ use CRM_Remoteevent_ExtensionUtil as E;
  */
 class GetCancelParticipantFormEvent extends GetParticipantFormEventBase
 {
+    const NAME = 'civi.remoteevent.cancellation.getform';
+
     /**
      * Get the token usage key for this event type
      *

--- a/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
@@ -26,6 +26,9 @@ use CRM_Remoteevent_ExtensionUtil as E;
  */
 class GetCreateParticipantFormEvent extends GetParticipantFormEventBase
 {
+
+    const NAME = 'civi.remoteevent.registration.getform';
+
     /**
      * GetCreateParticipantFormEvent constructor.
      */

--- a/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetUpdateParticipantFormEvent.php
@@ -28,6 +28,8 @@ use CRM_Remoteevent_ExtensionUtil as E;
  */
 class GetUpdateParticipantFormEvent extends GetParticipantFormEventBase
 {
+    const NAME = 'civi.remoteevent.registration_update.getform';
+
     /**
      * GetUpdateParticipantFormEvent constructor.
      */

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -27,6 +27,8 @@ use Civi\RemoteEvent;
  */
 class RegistrationEvent extends ChangingEvent
 {
+    const NAME = 'civi.remoteevent.registration.submit';
+
     /** @var array holds the original RemoteParticipant.submit data */
     protected $submission;
 

--- a/Civi/RemoteParticipant/Event/UpdateEvent.php
+++ b/Civi/RemoteParticipant/Event/UpdateEvent.php
@@ -28,6 +28,8 @@ use CRM_Remoteevent_ExtensionUtil as E;
  */
 class UpdateEvent extends ChangingEvent
 {
+    const NAME = 'civi.remoteevent.registration.update';
+
     /** @var array holds the original RemoteParticipant.submit data */
     protected $submission;
 

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -27,6 +27,9 @@ use Civi\RemoteEvent;
  */
 class ValidateEvent extends RemoteEvent
 {
+
+    const NAME = 'civi.remoteevent.registration.validate';
+
     /** @var array holds the original RemoteParticipant.validate submission */
     protected $submission;
 

--- a/Civi/RenderEvent.php
+++ b/Civi/RenderEvent.php
@@ -27,6 +27,8 @@ use \Symfony\Contracts\EventDispatcher\Event;
  */
 class RenderEvent extends Event
 {
+    const NAME = 'civi.remoteevent.render';
+
     /** @var string the full path to the template */
     protected $current_template_file;
 
@@ -161,7 +163,7 @@ class RenderEvent extends Event
     {
         // step 1: trigger the event
         $render_event = new RenderEvent($template_path, $smarty_variables, $context, $trim_mode);
-        \Civi::dispatcher()->dispatch('civi.remoteevent.render', $render_event);
+        \Civi::dispatcher()->dispatch(RenderEvent::NAME, $render_event);
 
         // step 2: load the template
         static $template_cache = [];

--- a/api/v3/RemoteEvent/Get.php
+++ b/api/v3/RemoteEvent/Get.php
@@ -59,7 +59,7 @@ function civicrm_api3_remote_event_get($params)
     $get_params->setParameter('event_remote_registration.remote_registration_enabled', 1);
 
     // dispatch search parameters event
-    Civi::dispatcher()->dispatch('civi.remoteevent.get.params', $get_params);
+    Civi::dispatcher()->dispatch(GetParamsEvent::NAME, $get_params);
 
     // use the basic event API for queries
     $event_get = $get_params->getParameters();
@@ -111,7 +111,7 @@ function civicrm_api3_remote_event_get($params)
 
 
     // dispatch the event in case somebody else wants to add/remove something
-    Civi::dispatcher()->dispatch('civi.remoteevent.get.result', $result);
+    Civi::dispatcher()->dispatch(GetResultEvent::NAME, $result);
 
     // finally, apply the limit
     if ($get_params->getLimit() != $get_params->getOriginalLimit()) {

--- a/api/v3/RemoteEvent/Getfields.php
+++ b/api/v3/RemoteEvent/Getfields.php
@@ -140,7 +140,7 @@ function civicrm_api3_remote_event_getfields_get($params)
     ]);
 
     // dispatch to others
-    Civi::dispatcher()->dispatch('civi.remoteevent.getfields', $fields_collection);
+    Civi::dispatcher()->dispatch(GetFieldsEvent::NAME, $fields_collection);
 
     // finally: add options to all the relevant fields
     foreach ($fields_collection->getFieldSpecs() as $field_name => $fieldSpec) {

--- a/api/v3/RemoteEvent/Spawn.php
+++ b/api/v3/RemoteEvent/Spawn.php
@@ -77,7 +77,7 @@ function civicrm_api3_remote_event_spawn($params)
     $create_params = new SpawnParamsEvent($params);
 
     // dispatch search parameters event and get parameters
-    Civi::dispatcher()->dispatch('civi.remoteevent.spawn.params', $create_params);
+    Civi::dispatcher()->dispatch(SpawnParamsEvent::NAME, $create_params);
     $event_create = $create_params->getParameters();
 
     // if there is a template_id id given, we want to clone that first

--- a/api/v3/RemoteParticipant/Cancel.php
+++ b/api/v3/RemoteParticipant/Cancel.php
@@ -108,7 +108,7 @@ function civicrm_api3_remote_participant_cancel($params)
 
     // pick the one that we want to cancel
     $cancellation_event = new CancelEvent($params, $participants);
-    Civi::dispatcher()->dispatch('civi.remoteevent.registration.cancel', $cancellation_event);
+    Civi::dispatcher()->dispatch(CancelEvent::NAME, $cancellation_event);
 
     // now simply take out the ones that we should cancel
     $cancellations = $cancellation_event->getParticipantCancellations();

--- a/api/v3/RemoteParticipant/Create.php
+++ b/api/v3/RemoteParticipant/Create.php
@@ -91,7 +91,7 @@ function civicrm_api3_remote_participant_create($params)
     // dispatch to the various handlers
     $registration_event = new RegistrationEvent($params);
     try {
-        Civi::dispatcher()->dispatch('civi.remoteevent.registration.submit', $registration_event);
+        Civi::dispatcher()->dispatch(RegistrationEvent::NAME, $registration_event);
     } catch (Exception $ex) {
         $registration_event->addError($ex->getMessage());
     }

--- a/api/v3/RemoteParticipant/GetForm.php
+++ b/api/v3/RemoteParticipant/GetForm.php
@@ -164,21 +164,21 @@ function civicrm_api3_remote_participant_get_form($params)
                 $fields = new GetCreateParticipantFormEvent($params, $event);
                 $fields->addStandardFields();
                 $fields->addStandardGreeting();
-                Civi::dispatcher()->dispatch('civi.remoteevent.registration.getform', $fields);
+                Civi::dispatcher()->dispatch(GetCreateParticipantFormEvent::NAME, $fields);
                 break;
 
             case 'cancel':
                 $fields = new GetCancelParticipantFormEvent($params, $event);
                 $fields->addStandardFields();
                 $fields->addStandardGreeting();
-                Civi::dispatcher()->dispatch('civi.remoteevent.cancellation.getform', $fields);
+                Civi::dispatcher()->dispatch(GetCancelParticipantFormEvent::NAME, $fields);
                 break;
 
             case 'update':
                 $fields = new GetUpdateParticipantFormEvent($params, $event);
                 $fields->addStandardFields();
                 $fields->addStandardGreeting();
-                Civi::dispatcher()->dispatch('civi.remoteevent.registration_update.getform', $fields);
+                Civi::dispatcher()->dispatch(GetUpdateParticipantFormEvent::NAME, $fields);
                 break;
         }
     } catch (Exception $error) {

--- a/api/v3/RemoteParticipant/Update.php
+++ b/api/v3/RemoteParticipant/Update.php
@@ -97,7 +97,7 @@ function civicrm_api3_remote_participant_update($params)
     // dispatch to the various handlers
     $update_event = new UpdateEvent($params);
     try {
-        Civi::dispatcher()->dispatch('civi.remoteevent.registration.update', $update_event);
+        Civi::dispatcher()->dispatch(UpdateEvent::NAME, $update_event);
     } catch (Exception $ex) {
         $update_event->addError($ex->getMessage());
     }

--- a/api/v3/RemoteParticipant/Validate.php
+++ b/api/v3/RemoteParticipant/Validate.php
@@ -103,12 +103,12 @@ function civicrm_api3_remote_participant_validate($params)
                 $validation->addError($cant_register_reason);
             } else {
                 // dispatch the validation event for other validations to weigh in
-                Civi::dispatcher()->dispatch('civi.remoteevent.registration.validate', $validation);
+                Civi::dispatcher()->dispatch(ValidateEvent::NAME, $validation);
             }
             break;
 
         case 'update':
-            Civi::dispatcher()->dispatch('civi.remoteevent.registration.validate', $validation);
+            Civi::dispatcher()->dispatch(ValidateEvent::NAME, $validation);
             break;
 
         case 'cancel':

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -16,6 +16,15 @@
 require_once 'remoteevent.civix.php';
 
 use CRM_Remoteevent_ExtensionUtil as E;
+use Civi\RemoteEvent\Event\GetParamsEvent;
+use Civi\RemoteEvent\Event\GetFieldsEvent;
+use Civi\RemoteEvent\Event\GetResultEvent;
+use Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent;
+use Civi\RemoteParticipant\Event\GetUpdateParticipantFormEvent;
+use Civi\RemoteParticipant\Event\ValidateEvent;
+use Civi\RemoteParticipant\Event\RegistrationEvent;
+use Civi\RemoteParticipant\Event\UpdateEvent;
+use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 
 /**
  * Implements hook_civicrm_config().
@@ -31,130 +40,130 @@ function remoteevent_civicrm_config(&$config)
 
     // EVENT GETFIELDS
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.getfields',
+          GetFieldsEvent::NAME,
         ['CRM_Remoteevent_EventLocation', 'addFieldSpecs']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.getfields',
+        GetFieldsEvent::NAME,
         ['CRM_Remoteevent_EventSpeaker', 'addFieldSpecs']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.getfields',
+        GetFieldsEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addFieldSpecs']);
 
     // EVENT GET PARAMETERS
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.params',
+        GetParamsEvent::NAME,
         ['CRM_Remoteevent_RemoteEvent', 'deriveEventID']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.params',
+        GetParamsEvent::NAME,
         ['CRM_Remoteevent_EventFlags', 'processFlagFilters']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.params',
+        GetParamsEvent::NAME,
         ['CRM_Remoteevent_EventCustomFields', 'processCustomFieldFilters']);
 
 
 
     // EVENT GET
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.result',
+        GetResultEvent::NAME,
         ['CRM_Remoteevent_EventFlags', 'calculateFlags'], 1000 /* at the very beginning */);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.result',
+        GetResultEvent::NAME,
         ['CRM_Remoteevent_EventFlags', 'applyFlagFilters'], -100 /** will trim entries */);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.result',
+        GetResultEvent::NAME,
         ['CRM_Remoteevent_EventLocation', 'addLocationData'], -1000 /** late */);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.result',
+        GetResultEvent::NAME,
         ['CRM_Remoteevent_EventSpeaker', 'addSpeakerData'], -1000 /** late */);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.get.result',
+        GetResultEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addSessionData'], -1000 /** late */);
 
     // EVENT REGISTRATION.GETFORM
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.getform',
+        GetCreateParticipantFormEvent::NAME,
             ['CRM_Remoteevent_RegistrationProfile', 'addProfileData']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.getform',
+       GetCreateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_Registration', 'addGtacField']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.getform',
+       GetCreateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addSessionFields']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.getform',
+       GetCreateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addRegisteredSessions']);
 
     // EVENT REGISTRATION_UPDATE.GETFORM
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration_update.getform',
+        GetUpdateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_RegistrationProfile', 'addProfileData']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration_update.getform',
+        GetUpdateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addSessionFields']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration_update.getform',
+        GetUpdateParticipantFormEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'addRegisteredSessions']);
 
 
 
     // EVENT REGISTRATION.VALIDATE
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.validate',
+        ValidateEvent::NAME,
             ['CRM_Remoteevent_RegistrationProfile', 'validateProfileData']);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.validate',
+        ValidateEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'validateSessionSubmission']);
 
     // EVENT REGISTRATION.SUBMIT
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'extractSessions'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_RegistrationProfile', 'addProfileContactData'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'identifyRemoteContact'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'createContactXCM'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'verifyContactNotRegistered'], CRM_Remoteevent_Registration::AFTER_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'confirmExistingParticipant'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 40);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'determineParticipantStatus'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 20);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'createParticipant'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.submit',
+        RegistrationEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'synchroniseSessions'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
 
     // EVENT REGISTRATION.UPDATE
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'extractSessions'], CRM_Remoteevent_RegistrationUpdate::STAGE1_PARTICIPANT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_RegistrationUpdate', 'loadParticipant'], CRM_Remoteevent_RegistrationUpdate::STAGE1_PARTICIPANT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_RegistrationUpdate', 'addProfileData'], CRM_Remoteevent_RegistrationUpdate::BEFORE_APPLY_CONTACT_CHANGES + 100);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_RegistrationUpdate', 'updateContact'], CRM_Remoteevent_RegistrationUpdate::STAGE2_APPLY_CONTACT_CHANGES);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_Registration', 'confirmExistingParticipant'], CRM_Remoteevent_RegistrationUpdate::STAGE3_APPLY_PARTICIPANT_CHANGES + 20);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_RegistrationUpdate', 'updateParticipant'], CRM_Remoteevent_RegistrationUpdate::STAGE3_APPLY_PARTICIPANT_CHANGES);
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.update',
+        UpdateEvent::NAME,
         ['CRM_Remoteevent_EventSessions', 'synchroniseSessions'], CRM_Remoteevent_RegistrationUpdate::AFTER_APPLY_PARTICIPANT_CHANGES);
 
     // EVENTMESSAGES.TOKENS
@@ -190,7 +199,7 @@ function remoteevent_civicrm_config(&$config)
 
     // TODO hier andere Profile hinzufügen
     $dispatcher->addUniqueListener(
-        'civi.remoteevent.registration.profile.list',
+        RegistrationProfileListEvent::NAME,
         ['CRM_Remoteevent_RegistrationProfile','addOptionValueProfiles']
     );
 

--- a/tests/phpunit/CRM/Remoteevent/ParticipantDataTest.php
+++ b/tests/phpunit/CRM/Remoteevent/ParticipantDataTest.php
@@ -62,7 +62,7 @@ class CRM_Remoteevent_ParticipantDataTest extends CRM_Remoteevent_TestBase
         ]);
 
         Civi::dispatcher()->addListener(
-            'civi.remoteevent.registration.submit',
+            RegistrationEvent::NAME,
             ['CRM_Remoteevent_ParticipantDataTest', 'registrationSetParticipantCampaign'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 20);
 
         // register one contact
@@ -91,7 +91,7 @@ class CRM_Remoteevent_ParticipantDataTest extends CRM_Remoteevent_TestBase
           ]);
 
         Civi::dispatcher()->addListener(
-            'civi.remoteevent.registration.submit',
+            RegistrationEvent::NAME,
             ['CRM_Remoteevent_ParticipantDataTest', 'registrationSetParticipantCampaign'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 20);
 
         // create invite participant


### PR DESCRIPTION
… for better navigation in IDEs. This had already been started by @pbatroff in some event classes, so this follows the existing naming scheme of `EventClass::NAME`.

This PR also makes use of `use` statements where applicable.