### PR TITLE
Translate event ID in`RemoteEvent.get` with `id` parameter

### DIFF
--- a/api/v3/RemoteEvent/Get.php
+++ b/api/v3/RemoteEvent/Get.php
@@ -58,6 +58,12 @@ function civicrm_api3_remote_event_get($params)
     // todo: only view the ones that are open for registration?
     $get_params->setParameter('event_remote_registration.remote_registration_enabled', 1);
 
+    // Translate event ID.
+    $original_params = $get_params->getOriginalParameters();
+    if (!empty($original_params['id'])) {
+      $get_params->setParameter('event_id', $original_params['id']);
+    }
+
     // dispatch search parameters event
     Civi::dispatcher()->dispatch(GetParamsEvent::NAME, $get_params);
 


### PR DESCRIPTION
When calling `RemoteEvent.get` with the `id` parameter set to the event ID, the event ID is currently being ignored due to `\CRM_Remoteevent_RemoteEvent::deriveEventID()` only looking for the`event_id` parameter.

This leads to all participant objects being queried with `Participant.get` in `\Civi\RemoteEvent::getParticipantID()` which will yield potentially incorrect values, as this API call limits to 1 result and passes `0` as `event_id`.

I'm not sure how this could have been working at all …

(Plus, passing `event_id=0` for the `Participant.get` API takes a code path that generates [invalid SQL in Core](https://github.com/civicrm/civicrm-core/blob/99553cb4f5556abb416b4325f9d34d42cf25df05/CRM/Event/BAO/Event.php#L279-L286) (`Incorrect DATETIME value ''`) (at least with MySQL 8 on my local machine), so I can't really test whether this affects anything else. - see https://chat.civicrm.org/civicrm/pl/rzobsp9wrbrhdm6z8x6h9kyj6o)

@bjendres do you see any issues with deriving `event_id` from `id` for `RemoteEvent.get`? Should this be done in `\CRM_Remoteevent_RemoteEvent::deriveEventID` instead?