### PR TITLE
Allow to specify entity field name in field spec

### DIFF
--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -13,11 +13,11 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
-use CRM_Remoteevent_ExtensionUtil as E;
+use Civi\Api4\Participant;
 use Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent;
 use Civi\RemoteParticipant\Event\RegistrationEvent;
 use Civi\RemoteParticipant\Event\UpdateParticipantEvent;
-use Civi\Api4\Participant;
+use CRM_Remoteevent_ExtensionUtil as E;
 
 /**
  * Class to execute event registrations (RemoteParticipant.create)
@@ -736,65 +736,32 @@ class CRM_Remoteevent_Registration
         CRM_Remoteevent_RemoteEvent::invalidateRemoteEvent($registration->getEventID());
     }
 
-    public static function registerAdditionalParticipants(RegistrationEvent $registration) {
-        if (
-            $registration->hasErrors()
-            || empty($registration->getAdditionalParticipantsData())
-        ) {
+    public static function registerAdditionalParticipants(RegistrationEvent $registration): void {
+        if ($registration->hasErrors() || [] === $registration->getAdditionalParticipantsData()) {
            return;
         }
 
-        $event = $registration->getEvent();
-        // The profile configured to be used for additional participants.
-        $profile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
-           $event['event_remote_registration.remote_registration_additional_participants_profile']
-        );
+        $additionalContactsData = $registration->getAdditionalContactsData();
+        $additionalParticipantsData = $registration->getAdditionalParticipantsData();
 
-        $additionalContactsData = [];
-        $additionalParticipantsData = [];
-
-        foreach ($registration->getAdditionalParticipantsData() as $additionalParticipantNo => $additionalParticipantData) {
-            $additionalParticipantsData[$additionalParticipantNo]['role_id'] = $additionalParticipantData['role_id'];
-            foreach ($profile->getFields() as $fieldKey => $fieldSpec) {
-                if (isset($additionalParticipantData[$fieldKey])) {
-                    $entity_names = (array)($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
-                    $entity_field_name = $fieldSpec['entity_field_name'] ?? $fieldKey;
-                    $value = isset($fieldSpec['value_callback'])
-                      ? $fieldSpec['value_callback']($additionalParticipantData[$fieldKey], $additionalParticipantData)
-                      : $additionalParticipantData[$fieldKey];
-
-                    if (in_array('Contact', $entity_names, TRUE)) {
-                        $additionalContactsData[$additionalParticipantNo][$entity_field_name] = $value;
-                    }
-                    if (in_array('Participant', $entity_names, TRUE)) {
-                        $additionalParticipantsData[$additionalParticipantNo][$entity_field_name] = $value;
-                    }
-                }
-            }
-        }
-
-        foreach ($additionalContactsData as $additionalParticipantNo => &$contactData) {
-            // Identify/Create contacts for additional participants.
-            $profile->modifyContactData($contactData);
-            $contactData['contact_type'] ??= 'Individual';
-            $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
-            CRM_Remoteevent_CustomData::resolveCustomFields($contactData);
+        foreach ($additionalContactsData as $participantNo => &$contactData) {
             $match = civicrm_api3('Contact', 'getorcreate', $contactData);
             if (!isset($match['id'])) {
-               throw new Exception('Contact for additional participant could not be identified or created.');
+               throw new \RuntimeException('Contact for additional participant could not be identified or created.');
             }
-            $additionalParticipantsData[$additionalParticipantNo]['contact_id'] = $match['id'];
+
+            $additionalParticipantsData[$participantNo]['contact_id'] = $contactData['id'] = $match['id'];
 
             // Check for existing participants for the identified contact.
             $cannotRegisterReason = CRM_Remoteevent_Registration::cannotRegister(
                 $registration->getEventID(),
-                $additionalParticipantsData[$additionalParticipantNo]['contact_id'],
+                $contactData['id'],
                 $registration->getEvent()
             );
             if ($cannotRegisterReason) {
                 $registration->addError(
                     E::ts('Additional participant %1: %2', [
-                        1 => $additionalParticipantNo,
+                        1 => $participantNo,
                         2 => $cannotRegisterReason,
                     ])
                 );
@@ -803,22 +770,25 @@ class CRM_Remoteevent_Registration
           // registering, and we want to collect all of them first.
         }
 
+        $registration->setAdditionalContactsData($additionalContactsData);
+
         // Abort if any additional participant can't be registered.
         if ($registration->hasErrors()) {
             return;
         }
 
         // Create additional participants.
-        $additionalParticipantsRegistered = [];
-        foreach ($additionalParticipantsData as $additionalParticipant) {
-            $additionalParticipantsRegistered[] = Participant::create(FALSE)
-                ->setValues($additionalParticipant)
-                ->addValue('event_id', $event['id'])
-                ->addValue('registered_by_id', $registration->getParticipantID())
+        foreach ($additionalParticipantsData as &$participantData) {
+            $participantData['registered_by_id'] = $registration->getParticipantID();
+            $participantRegistered = Participant::create(false)
+                ->setValues($participantData)
                 ->execute()
-                ->getArrayCopy();
+                ->single();
+
+            $participantData += $participantRegistered;
         }
-        $registration->setAdditionalParticipants($additionalParticipantsRegistered);
+
+        $registration->setAdditionalParticipantsData($additionalParticipantsData);
     }
 
     /**

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -744,13 +744,16 @@ class CRM_Remoteevent_Registration
         $additionalContactsData = $registration->getAdditionalContactsData();
         $additionalParticipantsData = $registration->getAdditionalParticipantsData();
 
-        foreach ($additionalContactsData as $participantNo => &$contactData) {
+        foreach ($additionalContactsData as $participantNo => $contactData) {
+            CRM_Remoteevent_CustomData::resolveCustomFields($contactData);
             $match = civicrm_api3('Contact', 'getorcreate', $contactData);
             if (!isset($match['id'])) {
                throw new \RuntimeException('Contact for additional participant could not be identified or created.');
             }
 
-            $additionalParticipantsData[$participantNo]['contact_id'] = $contactData['id'] = $match['id'];
+            $additionalParticipantsData[$participantNo]['contact_id']
+              = $additionalContactsData[$participantNo]['id']
+              = $contactData['id'] = $match['id'];
 
             // Check for existing participants for the identified contact.
             $cannotRegisterReason = CRM_Remoteevent_Registration::cannotRegister(

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -94,11 +94,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
      */
     abstract public function getFields($locale = null);
 
-    public function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): ?array
+    public function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
     {
+        $fields = [];
         if (!empty($event['is_multiple_registrations'])) {
-            $fields = [];
-
             $maxParticipants = min(
               $maxParticipants ?? $event['max_additional_participants'],
               $event['max_additional_participants']
@@ -130,7 +129,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
                 }
             }
         }
-        return $fields ?? NULL;
+        return $fields;
     }
 
     /**

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -13,6 +13,8 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
+use Civi\Api4\Participant;
+use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
 use CRM_Remoteevent_ExtensionUtil as E;
 
 use Civi\RemoteEvent as RemoteEvent;
@@ -65,7 +67,11 @@ abstract class CRM_Remoteevent_RegistrationProfile
      * @return array field specs
      *   format is field_key => [
      *      'name'        => field_key
-     *      'type'        => field type, one of 'Text', 'Textarea', 'Select', 'Multi-Select', 'Checkbox', 'Date'
+     *      'entity_name' => 'Contact' or 'Participant'.
+     *      'entity_field_name' => string, field_key if not set.
+     *      'type'        => field type, one of 'Text', 'Textarea', 'Select', 'Multi-Select', 'Checkbox', 'Date', 'Value', 'fieldset'.
+     *                       'Value' fields are not displayed and can be used for pre-defined values.
+     *                       'fieldset' is used to group fields.
      *      'weight'      => int,
      *      'options'     => [value => label (localised)] list  (optional)
      *      'required'    => 0/1
@@ -73,6 +79,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
      *      'description' => field description (localised)
      *      'parent'      => can link to parent element, which should be of type 'fieldset'
      *      'value'       => (optional) pre-filled value, typically set in a second pass (addDefaultValues, see below)
+     *      'value_callback' => (optional) callable(mixed, array<string, mixed>): mixed Called on submission for value conversion.
+     *         The first argument is the value itself, the second one the submission data.
+     *      'prefill_value_callback' => (optional) callable(mixed, array<string, mixed>): mixed Called when adding default values.
+     *         The first argument is the value itself, the second one the values of the same entity referenced by other fields.
      *      'maxlength'   => (optional) max length of the field content (as a string)
      *      'validation'  => content validation, see CRM_Utils_Type strings, but also custom ones like 'Email'
      *                       NOTE: this is just for the optional 'inline' validation in the form,
@@ -125,13 +135,44 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
     /**
      * Add the default values to the form data, so people using this profile
-     *  don't have to enter everything themselves
-     *
-     * @param GetParticipantFormEventBase $resultsEvent
-     *   the locale to use, defaults to null none. Use 'default' for current
-     *
+     * don't have to enter everything themselves.
      */
-    abstract public function addDefaultValues(GetParticipantFormEventBase $resultsEvent);
+    public function addDefaultValues(GetParticipantFormEventBase $resultsEvent)
+    {
+        $contact_field_mapping = [];
+        $participant_field_mapping = [];
+        $participant_value_callbacks = [];
+
+        foreach ($this->getFields() as $field_key => $field_spec) {
+            if (in_array($field_spec['type'], ['Value', 'fieldset'], TRUE)) {
+                continue;
+            }
+
+            $entity_names = (array) ($field_spec['entity_name'] ?? $this->getFieldEntities($field_key));
+            $entity_field_name = $field_spec['entity_field_name'] ?? $field_key;
+            if (in_array('Contact', $entity_names, TRUE)) {
+                $contact_field_mapping[$entity_field_name] = $field_key;
+            }
+            if (in_array('Participant', $entity_names, TRUE)) {
+                $participant_field_mapping[$entity_field_name] = $field_key;
+                if (isset($field_spec['prefill_value_callback'])) {
+                    $participant_value_callbacks[$field_key] = $field_spec['prefill_value_callback'];
+                }
+            }
+        }
+
+        $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
+
+        if ([] !== $participant_field_mapping && $resultsEvent->getParticipantID() > 0) {
+            $participant = Participant::get(FALSE)
+                ->setSelect(array_keys($participant_field_mapping))
+                ->addWhere('id', '=', $resultsEvent->getParticipantID())
+                ->execute()
+                ->single();
+
+            ParticipantFormEventUtil::mapToPrefill($participant, $participant_field_mapping, $resultsEvent, $participant_value_callbacks);
+        }
+    }
 
     /**
      * Validate the profile fields individually.
@@ -203,6 +244,8 @@ abstract class CRM_Remoteevent_RegistrationProfile
      *
      * @return array
      *   list of entities
+     *
+     * @deprecated Specify entity name in field spec instead.
      */
     public function getFieldEntities($field_key)
     {
@@ -477,43 +520,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
     }
 
     /**
-     * Use profile data to identify the contact via XCM
-     *
-     * @param array $data
-     *      Input data
-     *
-     * @param RegistrationEvent $registration
-     *      registration data
-     *
-     * @return integer
-     *      CiviCRM contact ID
-     *
-     * @throws Exception
-     *      If not enough information is provided
-     */
-    public static function addProfileContactData($registration)
-    {
-        // get the profile (has already been validated)
-        $profile = CRM_Remoteevent_RegistrationProfile::getProfile($registration);
-
-        // then simply add all fields from the profile
-        $contact_data = $registration->getContactData();
-        $submission_data = $registration->getSubmission();
-        foreach ($profile->getFields() as $field_key => $field_spec) {
-            if (isset($submission_data[$field_key])) {
-                $contact_data[$field_key] = $submission_data[$field_key];
-            }
-        }
-
-        // give the profile a chance to adjust contact data
-        $profile->adjustContactData($contact_data);
-
-        // finally, set the result
-        $registration->setContactData($contact_data);
-    }
-
-
-    /**
      * Does this profile have a dedicated XCM profile?
      *
      * @return string|null
@@ -710,34 +716,45 @@ abstract class CRM_Remoteevent_RegistrationProfile
     /**
      * Will set the default values for the given contact fields
      *
-     * @param GetParticipantFormEventBase $resultsEvent
-     *   the locale to use, defaults to null none. Use 'default' for current
-     *
-     * @param array $contact_fields
+     * @phpstan-param array<string> $contact_fields
      *   list of contact fields
      *
-     * @param array $attribute_mapping
+     * @phpstan-param array<string, string> $attribute_mapping
      *   maps the contact fields to the profile fields
      *
+     * @deprecated Overwrite addDefaultValues() if necessary.
      */
     public function addDefaultContactValues(GetParticipantFormEventBase $resultsEvent, $contact_fields, $attribute_mapping = [])
     {
         $contact_id = $resultsEvent->getContactID();
         if ($contact_id) {
+            $value_callbacks = [];
+            $profile = self::getProfile($resultsEvent);
+            $fields = $profile->getFields();
             // set contact data
+            $contact_fields = array_combine($contact_fields, $contact_fields);
+            // Assume that entity field name and profile field name are equal, if no mapping defined.
+            $attribute_mapping += $contact_fields;
+            foreach ($attribute_mapping as $field_key) {
+                if (isset($fields[$field_key]['prefill_value_callback'])) {
+                    $value_callbacks[$field_key] = $fields[$field_key]['prefill_value_callback'];
+                }
+            }
+            CRM_Remoteevent_CustomData::resolveCustomFields($contact_fields);
+            if (isset($contact_fields['country_id'])) {
+                // country_id is only returned if country is selected.
+                $contact_fields['country'] = 'country';
+            }
+            if (isset($contact_fields['state_province_id']) || isset($contact_fields['state_province_name'])) {
+                // state_province_id and state_province_name are only returned if state_province is selected
+                $contact_fields['state_province'] = 'state_province';
+            }
             try {
                 $contact_data = civicrm_api3('Contact', 'getsingle', [
                     'contact_id' => $contact_id,
-                    'return'     => implode(',', $contact_fields),
+                    'return'     => implode(',', array_keys($contact_fields)),
                 ]);
-                foreach ($contact_fields as $contact_field) {
-                    if (isset($attribute_mapping[$contact_field])) {
-                        $profile_field = $attribute_mapping[$contact_field];
-                    } else {
-                        $profile_field = $contact_field;
-                    }
-                    $resultsEvent->setPrefillValue($profile_field, $contact_data[$contact_field]);
-                }
+                ParticipantFormEventUtil::mapToPrefill($contact_data, $attribute_mapping, $resultsEvent, $value_callbacks);
             } catch (CiviCRM_API3_Exception $ex) {
                 // there is no (unique) primary email
             }
@@ -830,6 +847,5 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
         return $province_list;
     }
-
 
 }

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -39,16 +39,20 @@ class RegistrationEvent extends ChangingEvent
     protected $participant = [];
 
     /**
-     * @var array
+     * @phpstan-var array<int, array<string, mixed>>
+     *   Contact data of additional participants.
+     *
+     * @see $additional_participants_data
+     */
+    protected array $additional_contacts_data = [];
+
+    /**
+     * @phpstan-var array<int, array<string, mixed>>
      *   Data of additional participants.
+     *
+     * @see $additional_contacts_data
      */
     protected array $additional_participants_data = [];
-
-  /**
-   * @var array
-   *   Additionally registered participants.
-   */
-    protected array $additional_participants = [];
 
     public function __construct(array $submission_data)
     {
@@ -92,20 +96,8 @@ class RegistrationEvent extends ChangingEvent
      */
     public function setParticipant($participant)
     {
-        $this->participant_id = $participant['id'];
+        $this->participant_id = $participant['id'] ?? null;
         $this->participant = $participant;
-    }
-
-    /**
-     * Sets additionally registered participants.
-     *
-     * @param array $additionalParticipants
-     *
-     * @return void
-     */
-    public function setAdditionalParticipants(array $additionalParticipants): void
-    {
-        $this->additional_participants = $additionalParticipants;
     }
 
     /**
@@ -120,16 +112,6 @@ class RegistrationEvent extends ChangingEvent
     }
 
     /**
-     * Retrieves additionally registered participants.
-     *
-     * @return array
-     */
-    public function getAdditionalParticipants()
-    {
-        return $this->additional_participants;
-    }
-
-    /**
      * Get the participant data BY REFERENCE, which is used for
      *   registration creation / updates
      *
@@ -141,7 +123,33 @@ class RegistrationEvent extends ChangingEvent
         return $this->participant;
     }
 
-    public function &getAdditionalParticipantsData() {
+    /**
+     * @phpstan-return array<int, array<string, mixed>>
+     *
+     * @see getAdditionalParticipantsData()
+     */
+    public function getAdditionalContactsData(): array
+    {
+        return $this->additional_contacts_data;
+    }
+
+    /**
+     * @phpstan-param array<int, array<string, mixed>> $additional_contacts_data
+     *
+     * @see setAdditionalParticipantsData()
+     */
+    public function setAdditionalContactsData(array $additional_contacts_data): void
+    {
+        $this->additional_contacts_data = $additional_contacts_data;
+    }
+
+    /**
+     * @phpstan-return array<int, array<string, mixed>>
+     *
+     * @see getAdditionalContactsData()
+     */
+    public function getAdditionalParticipantsData(): array
+    {
         return $this->additional_participants_data;
     }
 

--- a/Civi/RemoteParticipant/Event/Util/ParticipantFormEventUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/ParticipantFormEventUtil.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Civi\RemoteParticipant\Event\Util;
+
+use Civi\RemoteParticipant\Event\GetParticipantFormEventBase;
+
+final class ParticipantFormEventUtil
+{
+    /**
+     * @phpstan-param array<string, mixed> $values
+     * @phpstan-param array<string, string> $mapping
+     *   Mapping of entity field names to profile field keys.
+     * @phpstan-param array<string, (callable(mixed, array<string, mixed): mixed)> $valueCallbacks
+     *
+     * @internal
+     */
+    public static function mapToPrefill(array $values, array $mapping, GetParticipantFormEventBase $event, array $valueCallbacks): void {
+        foreach ($mapping as $entity_field_name => $field_key) {
+            if (array_key_exists($entity_field_name, $values)) {
+                $value = isset($valueCallbacks[$field_key])
+                  ? $valueCallbacks[$field_key]($values[$entity_field_name], $values)
+                  : $values[$entity_field_name];
+                $event->setPrefillValue($field_key, $value);
+            }
+        }
+    }
+}

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Civi\RemoteParticipant;
+
+use Civi\RemoteParticipant\Event\RegistrationEvent;
+
+final class RegistrationEventFactory
+{
+    public function createRegistrationEvent(array $submission_data): RegistrationEvent {
+        $registrationEvent = new RegistrationEvent($submission_data);
+        $profile = \CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
+        $event = $registrationEvent->getEvent();
+
+        $contactData = [];
+        $participantData = [];
+        foreach ($profile->getFields() as $fieldKey => $fieldSpec) {
+            if (isset($submission_data[$fieldKey])) {
+                $entity_names = (array) ($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
+                $entity_field_name = $fieldSpec['entity_field_name'] ?? $fieldKey;
+                $value = isset($fieldSpec['value_callback'])
+                  ? $fieldSpec['value_callback']($submission_data[$fieldKey], $submission_data)
+                  : $submission_data[$fieldKey];
+
+                if (in_array('Contact', $entity_names, TRUE)) {
+                    $contactData[$entity_field_name] = $value;
+                }
+                if (in_array('Participant', $entity_names, TRUE)) {
+                    $participantData[$entity_field_name] = $value;
+                }
+            }
+        }
+
+        $participantData['role_id'] ??= $this->getDefaultRoleId($event);
+        $participantData['event_id'] = $submission_data['event_id'];
+
+        $profile->modifyContactData($contactData);
+
+        $registrationEvent->setContactData($contactData);
+        $registrationEvent->setParticipant($participantData);
+
+        // Create additional participants' data based on submission.
+        $registrationEvent->setAdditionalParticipantsData(
+          $this->getAdditionalParticipantsData($submission_data, $event)
+        );
+
+        return $registrationEvent;
+    }
+
+    /**
+     * @phpstan-param array<string, mixed> $submissionData
+     * @phpstan-param array<string, mixed> $event
+     *
+     * @phpstan-return array<array<string, mixed>>
+     */
+    private function getAdditionalParticipantsData(array $submissionData, array $event): array {
+        $additionalParticipantsData = [];
+        foreach ($submissionData as $key => $value) {
+            $additionalParticipantMatches =  [];
+            if (preg_match('#^additional_([0-9]+)_(.*?)$#', $key, $additionalParticipantMatches)) {
+                [, $participantNo, $fieldName] = $additionalParticipantMatches;
+                if ($participantNo <= $event['max_additional_participants']) {
+                    $additionalParticipantsData[$participantNo][$fieldName] = $value;
+                } else {
+                    throw new \Exception('Maximum number of additional participants exceeded');
+                }
+            }
+        }
+
+        foreach ($additionalParticipantsData as &$additionalParticipantData) {
+            $additionalParticipantData['role_id'] ??= $this->getDefaultRoleId($event);
+        }
+
+        return $additionalParticipantsData;
+    }
+
+    /**
+     * @param array<string, mixed> $event
+     */
+    private function getDefaultRoleId(array $event): int {
+        return (int) ($event['default_role_id'] ?: 1);  // 1 = Attendee
+    }
+}

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -55,7 +55,7 @@ final class RegistrationEventFactory
         $registrationEvent->setContactData($contactData);
         $registrationEvent->setParticipant($participantData);
 
-        $this->handleAdditionalParticipants($registrationEvent);
+        $this->handleAdditionalParticipants($registrationEvent, $profile);
 
         return $registrationEvent;
     }
@@ -64,17 +64,14 @@ final class RegistrationEventFactory
      * Handles additional participants' data in the submission data and sets the
      * resulting data in the event.
      */
-    private function handleAdditionalParticipants(RegistrationEvent $registrationEvent): void {
-        // Create additional participants' data based on submission.
+    private function handleAdditionalParticipants(RegistrationEvent $registrationEvent, \CRM_Remoteevent_RegistrationProfile $profile): void {
         $event = $registrationEvent->getEvent();
-        // The profile configured to be used for additional participants.
-        $profile = \CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
 
         $additionalContactsData = [];
         $additionalParticipantsData = [];
 
         $submissionData = $registrationEvent->getSubmission();
-        foreach ($profile->getAdditionalParticipantsFields($event) ?? [] as $fieldKey => $fieldSpec) {
+        foreach ($profile->getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
             $participantNo = $this->getAdditionalParticipantNo($fieldKey);
             if (null !== $participantNo && array_key_exists($fieldKey, $submissionData)) {
                 $entityNames = (array)($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -89,15 +89,19 @@ final class RegistrationEventFactory
             }
         }
 
-        foreach ($additionalContactsData as &$contactData) {
-            $profile->modifyContactData($contactData);
-            $contactData['contact_type'] ??= 'Individual';
-            $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
+        if ([] === $additionalParticipantsData) {
+            return;
         }
 
-        foreach ($additionalParticipantsData as &$participantData) {
-            $participantData['role_id'] ??= $this->getDefaultRoleId($event);
-            $participantData['event_id'] = $submissionData['event_id'];
+        $additionalParticipantsProfile = \CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+          $event['event_remote_registration.remote_registration_additional_participants_profile']
+        );
+        foreach ($additionalContactsData as $participantNo => &$contactData) {
+            $additionalParticipantsProfile->modifyContactData($contactData);
+            $contactData['contact_type'] ??= 'Individual';
+            $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
+            $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
+            $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
         }
 
         $registrationEvent->setAdditionalContactsData($additionalContactsData);

--- a/api/v3/RemoteParticipant/Create.php
+++ b/api/v3/RemoteParticipant/Create.php
@@ -89,7 +89,8 @@ function civicrm_api3_remote_participant_create($params)
     $registration_transaction = new CRM_Core_Transaction();
 
     // dispatch to the various handlers
-    $registration_event = new RegistrationEvent($params);
+    $registration_event_factory = new \Civi\RemoteParticipant\RegistrationEventFactory();
+    $registration_event = $registration_event_factory->createRegistrationEvent($params);
     try {
         Civi::dispatcher()->dispatch(RegistrationEvent::NAME, $registration_event);
     } catch (Exception $ex) {

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -131,9 +131,6 @@ function remoteevent_civicrm_config(&$config)
         ['CRM_Remoteevent_EventSessions', 'extractSessions'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,
-        ['CRM_Remoteevent_RegistrationProfile', 'addProfileContactData'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'identifyRemoteContact'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,


### PR DESCRIPTION
This change allows to use names for form fields different to the entity field names. Additionally it's now possible to specify value callbacks in the field spec (e.g. if the form field value is combined of two values for the dependent field functionality).

This fixes also loading of country_id and state_province_id (see code comments for details.)

systopia-reference: 23402