### PR TITLE
Fix method call in `civicrm_api3_remote_participant_create()`

### DIFF
--- a/api/v3/RemoteParticipant/Create.php
+++ b/api/v3/RemoteParticipant/Create.php
@@ -114,7 +114,7 @@ function civicrm_api3_remote_participant_create($params)
             'participant_role'   => $participant['participant_role'],
             'participant_status' => $participant['participant_status'],
             'participant_class'  => CRM_Remoteevent_Registration::getParticipantStatusClass($participant['participant_status_id']),
-            'additional_participants' => $registration_event->getAdditionalParticipants(),
+            'additional_participants' => $registration_event->getAdditionalParticipantsData(),
         ]);
     }
 }


### PR DESCRIPTION
Fixes error introduced by PR #60.