### PR TITLE
Increase minimal CiviCRM version to 5.61

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.2-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.45</ver>
+    <ver>5.61</ver>
   </compatibility>
   <comments/>
   <requires>


### PR DESCRIPTION
Because `ParticipantStatusType` is used the minimal CiviCRM version has to be increased to 5.61.
https://github.com/systopia/de.systopia.remoteevent/blob/22a87ea70b5c1c61931ae0e4dba0638b1c0e629b/CRM/Remoteevent/RemoteEvent.php#L343