### PR TITLE
Make localisation actually work

### DIFF
--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -66,15 +66,36 @@ class CRM_Remoteevent_Localisation
      * @return string
      *   localised result
      *
-     * @see CiviCRM's ts() function
+     * @see \ts()
+     *
+     * @deprecated 1.2.0 Deprecated in favor of self::ts().
+     * @see self::ts()
      */
     public function localise($string, $context = [])
     {
+        return self::ts($string, $context);
+    }
+
+    /**
+     * Localise a given string with this localisation.
+     *
+     * @param string $string
+     *   The (English) string to localise.
+     *
+     * @param array $context
+     *   Localisation parameters or variables.
+     *
+     * @return string
+     *   The localised version of the string.
+     *
+     * @see \ts()
+     */
+    public function ts($string, $context = []) {
         if (empty($this->locale)) {
-            // no changes, used for pot extraction
+            // No changes, used for pot extraction.
             return $string;
-        } else {
-            // todo: implement
+        }
+        else {
             $currentLocale = CRM_Core_I18n::getLocale();
             $locale = CRM_Core_I18n::singleton();
             $locale->setLocale($this->locale);

--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -75,7 +75,12 @@ class CRM_Remoteevent_Localisation
             return $string;
         } else {
             // todo: implement
-            return E::ts($string, $context);
+            $currentLocale = CRM_Core_I18n::getLocale();
+            $locale = CRM_Core_I18n::singleton();
+            $locale->setLocale($this->locale);
+            $localizedString = E::ts($string, $context);
+            $locale->setLocale($currentLocale);
+            return $localizedString;
         }
     }
 }


### PR DESCRIPTION
This hasn't been implemented yet, so localization only "works" for the default language (uses just `E::ts()`).

This makes it effectively impossible to have English labels when your CiviCRM's default language is not English.

This PR makes the locale be set globally before calling `E::ts()` and resets it afterwards. However, I'm not sure about possible side effects.

~~I consider this a bug, so set the milestone to `1.1` which is currently in beta and could receive bug fixes. If someone thinks this is too much of a change for beta, this will need to be postponed to `1.2` instead, which is currently in alpha.~~

*systopia-ref: 24106*