### PR TITLE
Use super method for providing default values in "Standard2" profile

### DIFF
--- a/CRM/Remoteevent/RegistrationProfile/Standard2.php
+++ b/CRM/Remoteevent/RegistrationProfile/Standard2.php
@@ -106,17 +106,4 @@ class CRM_Remoteevent_RegistrationProfile_Standard2 extends CRM_Remoteevent_Regi
             ],
         ];
     }
-
-    /**
-     * Add the default values to the form data, so people using this profile
-     *  don't have to enter everything themselves
-     *
-     * @param GetParticipantFormEventBase $resultsEvent
-     *   the locale to use, defaults to null none. Use 'default' for current
-     *
-     */
-    public function addDefaultValues(GetParticipantFormEventBase $resultsEvent)
-    {
-        $this->addDefaultContactValues($resultsEvent, ['prefix_id', 'email', 'formal_title', 'first_name', 'last_name']);
-    }
 }


### PR DESCRIPTION
This profile only uses Contact entity fields, which can be prepopulated with the generic super method added with #60.

This also allows for profiles inheriting from "Standard2" to use custom fields on Contact and Participant entities without writing their own implementation of the method.