### PR TITLE
Only assign default participant role for new participants

### DIFF
--- a/Civi/RemoteEvent.php
+++ b/Civi/RemoteEvent.php
@@ -88,10 +88,12 @@ abstract class RemoteEvent extends RemoteToolsRequest
     }
 
     /**
-     * Get the participant associated with this validation
-     *  (if any)
+     * Retrieves the ID of an existing participant.
+     *
+     * @return int|null
+     *    The participant ID, or NULL if this is a new participant.
      */
-    public function getParticipantID()
+    public function getParticipantID(): ?int
     {
         if ($this->participant_id === null) {
             $this->participant_id = 0; // don't look it up again

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -70,12 +70,9 @@ class RegistrationEvent extends ChangingEvent
     }
 
     /**
-     * Get the participant ID
-     *
-     * @return integer
-     *    contact ID
+     * {@inheritDoc}
      */
-    public function getParticipantID()
+    public function getParticipantID(): ?int
     {
         if (empty($this->participant['id'])) {
             $participant_id = parent::getParticipantID();

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -47,7 +47,10 @@ final class RegistrationEventFactory
             }
         }
 
-        $participantData['role_id'] ??= $this->getDefaultRoleId($event);
+        // Assign default role for new participants only.
+        if (NULL === $registrationEvent->getParticipantID()) {
+          $participantData['role_id'] ??= $this->getDefaultRoleId($event);
+        }
         $participantData['event_id'] = $submissionData['event_id'];
 
         $profile->modifyContactData($contactData);


### PR DESCRIPTION
… as otherwise for profiles that submit the `role_id` (e. g. in an invitation confirmation), the default role would always be used.

NB: I rebased the branch, effectively re-implementing the fix, as the underlying structure changed with #60, thus asking @dontub for a review.