### PR TITLE
Add support for monetary events

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -64,6 +64,10 @@ jobs:
 
           git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
           git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
+          git clone --depth=1 https://github.com/systopia/de.systopia.eventmessages ../de.systopia.eventmessages
+          git clone --depth=1 https://github.com/systopia/de.systopia.xportx ../de.systopia.xportx
+          git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider
+          git clone --depth=1 https://github.com/Project60/org.project60.sepa.git ../org.project60.sepa
 
           composer config --no-plugins allow-plugins.civicrm/composer-compile-plugin false
           composer config --no-plugins allow-plugins.civicrm/composer-downloads-plugin true

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -82,11 +82,6 @@ jobs:
             "civicrm/civicrm-packages:${{ inputs.civicrm-version }}"
           fi
 
-          # Until systopia/de.systopia.remotetools is officially released as composer package.
-          git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
-          composer config repositories.remotetools path $(dirname $PWD)/de.systopia.remotetools
-          composer require --no-update systopia/de.systopia.remotetools
-
           composer suggests --list | xargs -r composer require --no-update --${{ matrix.prefer }} --ignore-platform-reqs
 
           git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -62,6 +62,9 @@ jobs:
             export COMPOSER_NO_SECURITY_BLOCKING=1
           fi
 
+          git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
+          git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
+
           composer config --no-plugins allow-plugins.civicrm/composer-compile-plugin false
           composer config --no-plugins allow-plugins.civicrm/composer-downloads-plugin true
           composer config --no-plugins allow-plugins.composer/installers true

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -78,6 +78,11 @@ jobs:
 
           git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
           git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
+          git clone --depth=1 https://github.com/systopia/de.systopia.eventmessages ../de.systopia.eventmessages
+          git clone --depth=1 https://github.com/systopia/de.systopia.xportx ../de.systopia.xportx
+          git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider
+          git clone --depth=1 https://github.com/Project60/org.project60.sepa.git ../org.project60.sepa
+
 
           EXT_DIR=$PWD
           EXT_COMPOSER_NAME=$(composer show --self --name-only)

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -76,6 +76,9 @@ jobs:
           # Prevent this git error: The repository does not have the correct ownership and git refuses to use it
           git config --global --add safe.directory "$PWD"
 
+          git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
+          git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
+
           EXT_DIR=$PWD
           EXT_COMPOSER_NAME=$(composer show --self --name-only)
           composer composer-phpunit -- update --no-progress --optimize-autoloader

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -76,14 +76,6 @@ jobs:
           # Prevent this git error: The repository does not have the correct ownership and git refuses to use it
           git config --global --add safe.directory "$PWD"
 
-          git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
-          git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
-          git clone --depth=1 https://github.com/systopia/de.systopia.eventmessages ../de.systopia.eventmessages
-          git clone --depth=1 https://github.com/systopia/de.systopia.xportx ../de.systopia.xportx
-          git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider
-          git clone --depth=1 https://github.com/Project60/org.project60.sepa.git ../org.project60.sepa
-
-
           EXT_DIR=$PWD
           EXT_COMPOSER_NAME=$(composer show --self --name-only)
           composer composer-phpunit -- update --no-progress --optimize-autoloader

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+*.orig
+*.swp
+*BACKUP*
+*BASE*
+*LOCAL*
+*REMOTE*
 /.phpcs.cache
 /.phpunit.result.cache
 /.phpstan/

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -596,10 +596,7 @@ class CRM_Remoteevent_Registration {
 
     public static function createOrder(RegistrationEvent $registration): void {
       $event = $registration->getEvent();
-      if (
-        (bool) $event['is_monetary']
-        && class_exists('\Civi\Api4\Order')
-      ) {
+      if ((bool) $event['is_monetary']) {
         $order = \Civi\Api4\Order::create(FALSE)
           ->setContributionValues([
             'contact_id' => $registration->getContactID(),

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -16,6 +16,7 @@
 declare(strict_types = 1);
 
 use Civi\Api4\Participant;
+use Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent;
 use Civi\RemoteParticipant\Event\RegistrationEvent;
 use Civi\RemoteParticipant\Event\UpdateParticipantEvent;
 use CRM_Remoteevent_ExtensionUtil as E;
@@ -125,6 +126,12 @@ class CRM_Remoteevent_Registration {
 
   /**
    * Get a list of participant objects
+     *
+     * @param integer $event_id
+     *   the event
+     *
+     * @param integer $contact_id
+     *   the contact
    */
   public static function invalidateRegistrationCache($contact_id, $event_id) {
     // unset the registration data
@@ -132,7 +139,7 @@ class CRM_Remoteevent_Registration {
 
     // update the indicator
     $event_cached_key = array_search($event_id, self::$cached_registration_event_ids);
-    if ($event_cached_key !== FALSE) {
+    if (FALSE !== $event_cached_key) {
       unset(self::$cached_registration_event_ids[$event_cached_key]);
     }
   }
@@ -197,8 +204,7 @@ class CRM_Remoteevent_Registration {
       if ($registered_count >= $event_data['max_participants']) {
         if (empty($event_data['event_full_text'])) {
           return E::ts('Event is booked out');
-        }
-        else {
+        } else {
           return $event_data['event_full_text'];
         }
       }
@@ -292,15 +298,13 @@ class CRM_Remoteevent_Registration {
     if (empty($event_data['selfcancelxfer_time'])) {
       // no restrictions
       return TRUE;
-    }
-    else {
+    } else {
       $min_seconds_before_start = 60 * 60 * (int) $event_data['selfcancelxfer_time'];
       $current_seconds_before_start = strtotime($event_data['start_date']) - strtotime('now');
       if ($current_seconds_before_start > $min_seconds_before_start) {
         // we can still cancel
         return TRUE;
-      }
-      else {
+      } else {
         // we're too close to the event starting date
         return FALSE;
       }
@@ -385,8 +389,7 @@ class CRM_Remoteevent_Registration {
     if (!empty($event_data['enabled_profiles'])) {
       $enabled_profiles = explode(',', $event_data['enabled_profiles']);
       return in_array('OneClick', $enabled_profiles);
-    }
-    else {
+    } else {
       return FALSE;
     }
   }
@@ -407,6 +410,9 @@ class CRM_Remoteevent_Registration {
     if (empty($event_data)) {
       $event_data = CRM_Remoteevent_RemoteEvent::getRemoteEvent($event_id);
     }
+
+    return !empty($event_data['event_remote_registration.remote_registration_suspended']);
+  }
 
   /**
    * Retrieves the count of current registrations for the given event.
@@ -430,12 +436,12 @@ class CRM_Remoteevent_Registration {
    *   number of registrations (participant objects)
    */
   public static function getRegistrationCount(
-    $event_id,
-    $contact_id = NULL,
-    array $class_list = [],
-    array $status_id_list = [],
-    bool $only_counted = TRUE
-  ): int {
+        $event_id,
+        $contact_id = NULL,
+        array $class_list = [],
+        array $status_id_list = [],
+        bool $only_counted = TRUE
+    ): int {
     $event_id = (int) $event_id;
     $contact_id = (int) $contact_id;
 
@@ -519,6 +525,21 @@ class CRM_Remoteevent_Registration {
     return (int) CRM_Core_DAO::singleValueQuery($query);
   }
 
+  /**
+   * Create or identify the contact based on the collected data
+   *
+   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
+   *      event triggered by the RemoteParticipant.submit
+   */
+  public static function createContactXCM($registration) {
+    // get collected contact data
+    $contact_identification = $registration->getContactData();
+
+    // add contact type if it's missing
+    if (empty($contact_identification['contact_type'])) {
+      $contact_identification['contact_type'] = 'Individual';
+    }
+
     if (!$registration->isContactUpdated()) {
       if ($registration->getContactID()) {
         // in this case we use the XCM with the update profile with the ID set
@@ -531,15 +552,13 @@ class CRM_Remoteevent_Registration {
         CRM_Remoteevent_CustomData::resolveCustomFields($contact_identification);
         $match = civicrm_api3('Contact', 'getorcreate', $contact_identification);
 
-      }
-      catch (Exception $ex) {
+      } catch (Exception $ex) {
         if (empty($contact_identification['id'])) {
           // no contact ID given -> there must be some data missing
           throw new Exception(
           E::ts("Couldn't find or create contact: ") . $ex->getMessage());
 
-        }
-        else {
+        } else {
           // the contact ID ws passed, but it still failed.
           // first: check if options.match_contact_id is set
           $profile_name = $contact_identification['xcm_profile'];
@@ -549,8 +568,7 @@ class CRM_Remoteevent_Registration {
               // phpcs:ignore Generic.Files.LineLength.TooLong
               "RemoteEvent: maybe you should activate the 'Match contacts by contact ID' option for your '{$profile_name}' profile, so that contact updates could also be applied if the participant is only identified by ID."
             );
-          }
-          else {
+          } else {
             throw new Exception(E::ts('Error while updating contact %1: %2', [
               1 => $contact_identification['id'],
               2 => $ex->getMessage(),
@@ -592,125 +610,49 @@ class CRM_Remoteevent_Registration {
       return;
     }
 
-    public static function createOrder(RegistrationEvent $registration): void {
-      $event = $registration->getEvent();
-      if ((bool) $event['is_monetary']) {
-        $order = \Civi\Api4\Order::create(FALSE)
-          ->setContributionValues([
-            'contact_id' => $registration->getContactID(),
-            'financial_type_id' => (int) $event['financial_type_id'],
-            'payment_instrument_id' => static::getPaymentInstrumentForPaymentMethod(
-              $registration->getSubmittedValue('payment_method'),
-              $event
-            )
-          ]);
-        foreach ($registration->getPriceFieldValues() as $value) {
-          $order->addLineItem([
-            'entity_table' => 'civicrm_participant',
-            'entity_id' => $value['participant_id'],
-            'price_field_id' => $value['price_field_id'],
-            'price_field_value_id' => $value['price_field_value_id'],
-            'qty' => $value['qty'],
-          ]);
-        }
-        try {
-          $orderResult = $order
-            ->execute()
-            ->single();
-          $registration->setOrderData($orderResult);
-        }
-        catch (CRM_Core_Exception $exception) {
-          $registration->addError(E::ts('Could not register order.'));
-        }
-      }
+    // now, after the contact has been identified, make sure (s)he's not already registered
+    $cant_register_reason = CRM_Remoteevent_Registration::cannotRegister(
+      $registration->getEventID(),
+      $registration->getContactID(),
+      $registration->getEvent()
+    );
+    if ($cant_register_reason) {
+      $registration->addError($cant_register_reason);
     }
+  }
 
   /**
-   * @phpstan-param array{
-   *   id: int,
-   *   currency: string,
-   *   fee_label: string,
-   *   is_monetary: int,
-   * } $event
+   * If there is already an existing participant,
+   *  process the confirmation
+   *
+   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
+   *   registration event
    */
-    public static function getPaymentInstrumentForPaymentMethod(string $paymentMethod, array $event): int {
-      switch ($paymentMethod) {
-        case 'pay_later':
-          // TODO: Make payment method for "Pay later" configurable per event.
-          return (int) \Civi\Api4\OptionValue::get(FALSE)
-            ->addSelect('value')
-            ->addWhere('option_group_id.name', '=', 'payment_instrument')
-            ->addWhere('name', '=', 'EFT')
-            ->execute()['value'];
-
-        case 'sepa':
-          // Use OOFF payment instrument from creditor.
-          // TODO: Make creditor configurable per event.
-          return (int) \CRM_Sepa_Logic_Settings::defaultCreditor()->pi_ooff;
-      }
+  public static function confirmExistingParticipant($registration) {
+    // of there is already an issue, don't waste any more time on this
+    if ($registration->hasErrors()) {
+      return;
     }
 
-    public static function createPayment(RegistrationEvent $registration): void {
-      $event = $registration->getEvent();
-      if ((bool) $event['is_monetary']) {
-        $order = $registration->getOrderData();
-
-        switch ($registration->getSubmittedValue('payment_method')) {
-          case 'pay_later':
-            // Nothing to do here, there is already a pending contribution.
-            break;
-
-          case 'sepa':
-            $mandate = \Civi\Api4\SepaMandate::create(FALSE)
-              ->addValue('creditor_id', NULL)
-              ->addValue('type', 'OOFF')
-              ->addValue('iban', $registration->getSubmittedValue('payment_method_sepa_iban'))
-              ->addValue('bic', $registration->getSubmittedValue('payment_method_sepa_bic'))
-              ->addValue('status', 'OOFF')
-              // Reference is given a default when empty(), but is a required field, thus passing 0.
-              // TODO: Adjust CiviSEPA to not make the API parameter required if there is a default, and do not pass a
-              //       a value once that's done.
-              ->addValue('reference', 0)
-              ->addValue('entity_table', 'civicrm_contribution')
-              ->addValue('entity_id', $order['id'])
-              ->addValue('contact_id', $registration->getContactID())
-              ->addValue('currency', $event['currency'])
-              ->addValue('date', $order['receive_date'])
-              ->addValue('creation_date', $order['receive_date'])
-              ->addValue('validation_date', $order['receive_date'])
-              ->execute();
-            break;
-
-          default:
-            // TODO: Register submitted payment (API to be defined; must include the amount and the date, possibly a
-            //       transaction ID, etc.) using \Civi\Api4\Payment::create().
-            break;
-        }
-      }
-    }
-
-    /**
-     * Get a (cached version) of ParticipantStatusType.get
-     */
-    public static function getParticipantStatusList()
-    {
-        static $status_list = null;
-        if ($status_list === null) {
-            $status_list = [];
-            $query = civicrm_api3('ParticipantStatusType', 'get', ['option.limit' => 0]);
-            foreach ($query['values'] as $status) {
-                $status_list[$status['id']] = $status;
-            }
-        }
-        else {
+    $participant_id = $registration->getParticipantID();
+    $submission = $registration->getSubmission();
+    if (isset($submission['confirm'])) {
+      if ($participant_id) {
+        // there is already a (pre-existing) participant
+        //   ... and the 'confirm' flag has been submitted
+        //   then: update the participant right away
+        $new_status = '';
+        if (empty($submission['confirm'])) {
+          // participant want's out
+          $new_status = 'Rejected';
+        } else {
           // participant wants to confirm
           if (CRM_Remoteevent_RemoteEvent::hasActiveWaitingList(
                 $registration->getEventID(),
                 $registration->getEvent()
             )) {
             $new_status = 'On waitlist';
-          }
-          else {
+          } else {
             $new_status = 'Registered';
           }
         }
@@ -727,8 +669,7 @@ class CRM_Remoteevent_Registration {
         // mark as updated to avoid additional calls
         // see also: https://github.com/systopia/de.systopia.remoteevent/issues/19
         $registration->setParticipantUpdated();
-      }
-      else {
+      } else {
         // there is no pre-existing participant, just add to the general to-be-created one
         if (empty($submission['confirm'])) {
           $participant = &$registration->getParticipantData();
@@ -736,5 +677,338 @@ class CRM_Remoteevent_Registration {
         }
       }
     }
+  }
+
+  /**
+   * Will calculate the participant status
+   *
+   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
+   *   registration event
+   */
+  public static function determineParticipantStatus($registration) {
+    // of there is already an issue, don't waste any more time on this
+    if ($registration->hasErrors()) {
+      return;
+    }
+
+    if ($registration->getParticipantID()) {
+      // there is already a registration identified
+      return;
+    }
+
+    // default status calculation
+    $participant_data = &$registration->getParticipantData();
+    $event_data = $registration->getEvent();
+
+    // check if this has a waiting list
+    if (empty($participant_data['participant_status_id'])) {
+      if (CRM_Remoteevent_RemoteEvent::hasActiveWaitingList($event_data['id'], $event_data)) {
+        $participant_data['participant_status_id'] = 'On waitlist';
+
+        if (!empty($event_data['waitlist_text'])) {
+          $registration->addStatus($event_data['waitlist_text']);
+        } else {
+          $registration->addStatus(E::ts('You have been added to the waitlist.'));
+        }
+      }
+    }
+
+    // check if it registration requires approval
+    if (empty($participant_data['participant_status_id'])) {
+      if (!empty($event_data['requires_approval'])) {
+        // there is an active waiting list, see if need to get on it
+        $participant_data['participant_status_id'] = 'Awaiting approval';
+      }
+    }
+
+    // finally: the default status is Registered
+    if (empty($participant_data['participant_status_id'])) {
+      $participant_data['participant_status_id'] = 'Registered';
+    }
+  }
+
+  /**
+   * Will create a simple participant object
+   *
+   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
+   *   registration event
+   */
+  public static function createParticipant($registration) {
+    // of there is already an issue, don't waste any more time on this
+    if ($registration->hasErrors()) {
+      return;
+    }
+
+    // let's look into this
+    $participant_data = &$registration->getParticipantData();
+
+    if ($registration->getParticipantID()) {
+      // this is updating an existing participant
+      $participant_data['id'] = $registration->getParticipantID();
+      if (!$registration->isParticipantUpdated()) {
+        $participant_data['force_trigger_eventmessage'] = 1;
+      }
+
+        } else {
+      // we're creating an all new participant
+      if (!isset($participant_data['contact_id'])) {
+        $participant_data['contact_id'] = $registration->getContactID();
+      }
+    }
+
+    // Modify Participant Data Event here. This can be used to maybe manually update/set participant data
+    $update_participant_event = new UpdateParticipantEvent($participant_data);
+    // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
+    Civi::dispatcher()->dispatch(UpdateParticipantEvent::NAME, $update_participant_event);
+    $participant_data = $update_participant_event->get_participant_data();
+
+    // run create/update
+    CRM_Remoteevent_CustomData::resolveCustomFields($participant_data);
+    $creation = civicrm_api3('Participant', 'create', $participant_data);
+    $registration->setParticipantUpdated();
+    $participant = civicrm_api3('Participant', 'getsingle', ['id' => $creation['id']]);
+    CRM_Remoteevent_CustomData::labelCustomFields($participant);
+    $registration->setParticipant($participant);
+
+    // invalidate caches
+    self::invalidateRegistrationCache($participant_data['contact_id'], $participant_data['event_id']);
+    CRM_Remoteevent_RemoteEvent::invalidateRemoteEvent($registration->getEventID());
+  }
+
+  public static function registerAdditionalParticipants(RegistrationEvent $registration): void {
+    if ($registration->hasErrors() || [] === $registration->getAdditionalParticipantsData()) {
+      return;
+    }
+
+    $additionalContactsData = $registration->getAdditionalContactsData();
+    $additionalParticipantsData = $registration->getAdditionalParticipantsData();
+
+    foreach ($additionalContactsData as $participantNo => $contactData) {
+      CRM_Remoteevent_CustomData::resolveCustomFields($contactData);
+      $match = civicrm_api3('Contact', 'getorcreate', $contactData);
+      if (!isset($match['id'])) {
+        throw new \RuntimeException('Contact for additional participant could not be identified or created.');
+      }
+
+      $additionalParticipantsData[$participantNo]['contact_id']
+        = $additionalContactsData[$participantNo]['id']
+        = $contactData['id'] = $match['id'];
+
+      // Check for existing participants for the identified contact.
+      $cannotRegisterReason = CRM_Remoteevent_Registration::cannotRegister(
+        $registration->getEventID(),
+        $contactData['id'],
+        $registration->getEvent()
+      );
+      if ($cannotRegisterReason) {
+        $registration->addError(
+        E::ts('Additional participant %1: %2', [
+          1 => $participantNo,
+          2 => $cannotRegisterReason,
+        ])
+        );
+      }
+      // Do not register participants yet, as there might be reasons for not
+      // registering, and we want to collect all of them first.
+    }
+
+    $registration->setAdditionalContactsData($additionalContactsData);
+
+    // Abort if any additional participant can't be registered.
+    if ($registration->hasErrors()) {
+      return;
+    }
+
+    // Create additional participants.
+    foreach ($additionalParticipantsData as &$participantData) {
+      $participantData['registered_by_id'] = $registration->getParticipantID();
+      $participantData['register_date'] = date('Y-m-d H:i');
+      $participantRegistered = Participant::create(FALSE)
+        ->setValues($participantData)
+        ->execute()
+        ->single();
+
+      $participantData += $participantRegistered;
+    }
+
+    $registration->setAdditionalParticipantsData($additionalParticipantsData);
+  }
+
+  public static function createOrder(RegistrationEvent $registration): void {
+    $event = $registration->getEvent();
+    if ((bool) $event['is_monetary']) {
+      $order = \Civi\Api4\Order::create(FALSE)
+        ->setContributionValues([
+          'contact_id' => $registration->getContactID(),
+          'financial_type_id' => (int) $event['financial_type_id'],
+          'payment_instrument_id' => static::getPaymentInstrumentForPaymentMethod(
+            $registration->getSubmittedValue('payment_method'),
+            $event
+          )
+        ]);
+      foreach ($registration->getPriceFieldValues() as $value) {
+        $order->addLineItem([
+          'entity_table' => 'civicrm_participant',
+          'entity_id' => $value['participant_id'],
+          'price_field_id' => $value['price_field_id'],
+          'price_field_value_id' => $value['price_field_value_id'],
+          'qty' => $value['qty'],
+        ]);
+      }
+      try {
+        $orderResult = $order
+          ->execute()
+          ->single();
+        $registration->setOrderData($orderResult);
+      }
+      catch (CRM_Core_Exception $exception) {
+        $registration->addError(E::ts('Could not register order.'));
+      }
+    }
+  }
+
+  /**
+   * @phpstan-param array{
+   *   id: int,
+   *   currency: string,
+   *   fee_label: string,
+   *   is_monetary: int,
+   * } $event
+   */
+  public static function getPaymentInstrumentForPaymentMethod(string $paymentMethod, array $event): int {
+    switch ($paymentMethod) {
+      case 'pay_later':
+        // TODO: Make payment method for "Pay later" configurable per event.
+        return (int) \Civi\Api4\OptionValue::get(FALSE)
+          ->addSelect('value')
+          ->addWhere('option_group_id.name', '=', 'payment_instrument')
+          ->addWhere('name', '=', 'EFT')
+          ->execute()['value'];
+
+      case 'sepa':
+        // Use OOFF payment instrument from creditor.
+        // TODO: Make creditor configurable per event.
+        return (int) \CRM_Sepa_Logic_Settings::defaultCreditor()->pi_ooff;
+    }
+  }
+
+  public static function createPayment(RegistrationEvent $registration): void {
+    $event = $registration->getEvent();
+    if ((bool) $event['is_monetary']) {
+      $order = $registration->getOrderData();
+
+      switch ($registration->getSubmittedValue('payment_method')) {
+        case 'pay_later':
+          // Nothing to do here, there is already a pending contribution.
+          break;
+
+        case 'sepa':
+          $mandate = \Civi\Api4\SepaMandate::create(FALSE)
+            ->addValue('creditor_id', NULL)
+            ->addValue('type', 'OOFF')
+            ->addValue('iban', $registration->getSubmittedValue('payment_method_sepa_iban'))
+            ->addValue('bic', $registration->getSubmittedValue('payment_method_sepa_bic'))
+            ->addValue('status', 'OOFF')
+            // Reference is given a default when empty(), but is a required field, thus passing 0.
+            // TODO: Adjust CiviSEPA to not make the API parameter required if there is a default, and do not pass a
+            //       a value once that's done.
+            ->addValue('reference', 0)
+            ->addValue('entity_table', 'civicrm_contribution')
+            ->addValue('entity_id', $order['id'])
+            ->addValue('contact_id', $registration->getContactID())
+            ->addValue('currency', $event['currency'])
+            ->addValue('date', $order['receive_date'])
+            ->addValue('creation_date', $order['receive_date'])
+            ->addValue('validation_date', $order['receive_date'])
+            ->execute();
+          break;
+
+        default:
+          // TODO: Register submitted payment (API to be defined; must include the amount and the date, possibly a
+          //       transaction ID, etc.) using \Civi\Api4\Payment::create().
+          break;
+      }
+    }
+  }
+
+  /**
+   * Get a (cached version) of ParticipantStatusType.get
+   */
+  public static function getParticipantStatusList() {
+    static $status_list = NULL;
+    if (NULL === $status_list) {
+      $status_list = [];
+      $query = civicrm_api3('ParticipantStatusType', 'get', ['option.limit' => 0]);
+      foreach ($query['values'] as $status) {
+        $status_list[$status['id']] = $status;
+      }
+    }
+    return $status_list;
+  }
+
+  /**
+   * Get a the class of the given status ID
+   *
+   * @param integer $participant_status_id
+   *   the status id
+   *
+   * @return string
+   *   class name: 'Positive', 'Negative', 'Pending'...
+   */
+  public static function getParticipantStatusClass($participant_status_id) {
+    $status_list = self::getParticipantStatusList();
+    $status = $status_list[$participant_status_id];
+    return $status['class'];
+  }
+
+  /**
+   * Get a the name of the given status ID
+   *
+   * @param integer $participant_status_id
+   *   the status id
+   *
+   * @return string
+   *   status (internal) name: 'Registered', 'Attended', ...
+   */
+  public static function getParticipantStatusName($participant_status_id) {
+    $status_list = self::getParticipantStatusList();
+    $status = $status_list[$participant_status_id];
+    return $status['name'];
+  }
+
+  /**
+   * Add the GTAC data to the get_form results
+   *
+   * @param \Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent $get_form_results
+   *      event triggered by the RemoteParticipant.get_form API call
+   */
+  public static function addGtacField($get_form_results) {
+    $event = $get_form_results->getEvent();
+    if (!empty($event['event_remote_registration.remote_registration_gtac'])) {
+      $l10n = $get_form_results->getLocalisation();
+      $get_form_results->addFields([
+        'gtacs' => [
+          'type'        => 'fieldset',
+          'name'        => 'gtacs',
+          'label'       => $l10n->ts('General Terms and Conditions'),
+        // this should be at the end
+          'weight'      => 500,
+        ],
+        'gtac' => [
+          'name' => 'gtac',
+          'type' => 'Checkbox',
+          'validation' => '',
+          'weight' => 100,
+          'required' => 1,
+          'label' => $l10n->ts('I accept the following terms and conditions'),
+          'description' => '', //$l10n->ts("You have to accept the terms and conditions to participate in this event"),
+          'parent' => 'gtacs',
+          'suffix' => $event['event_remote_registration.remote_registration_gtac'],
+          'suffix_display' => 'inline',
+          'suffix_dialog_label' => $l10n->ts('Details'),
+        ]
+      ]);
+    }
+  }
 
 }

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -598,7 +598,7 @@ class CRM_Remoteevent_Registration {
         $order = \Civi\Api4\Order::create(FALSE)
           ->setContributionValues([
             'contact_id' => $registration->getContactID(),
-            'financial_type_id' => $event['financial_type_id'],
+            'financial_type_id' => (int) $event['financial_type_id'],
           ]);
         foreach ($registration->getPriceFieldValues() as $value) {
           $order->addLineItem([

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -602,8 +602,9 @@ class CRM_Remoteevent_Registration {
           $order->addLineItem([
             'entity_table' => 'civicrm_participant',
             'entity_id' => $value['participant_id'],
+            'price_field_id' => $value['price_field_id'],
             'price_field_value_id' => $value['price_field_value_id'],
-            'qty' => $value['qty']
+            'qty' => $value['qty'],
           ]);
         }
         $order->execute();

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -408,49 +408,46 @@ class CRM_Remoteevent_Registration {
       $event_data = CRM_Remoteevent_RemoteEvent::getRemoteEvent($event_id);
     }
 
-    return !empty($event_data['event_remote_registration.remote_registration_suspended']);
-  }
-
   /**
-   * Get the count of current registrations for the given event
+   * Retrieves the count of current registrations for the given event.
    *
-   * @param integer $event_id
-   *    event ID
+   * @param int $event_id
+   *   event ID
    *
-   * @param integer $contact_id
-   *    restrict to this contact
+   * @param int $contact_id
+   *   restrict to this contact
    *
    * @param array $class_list
-   *    list of participant status classes to be included - default is ony positive statuses
+   *   list of participant status classes to be included - default is ony positive statuses
    *
    * @param array $status_id_list
-   *    list of participant status ids to be included - default is <all>
+   *   list of participant status ids to be included - default is <all>
    *
-   * @param boolean $only_counted
-   *    only count registration where the status_type has is_counted = 1
+   * @param bool $only_counted
+   *   only count registration where the status_type has is_counted = 1
    *
    * @return int
    *   number of registrations (participant objects)
    */
   public static function getRegistrationCount(
-        $event_id,
-        $contact_id = NULL,
-        array $class_list = [],
-        array $status_id_list = [],
-        bool $only_counted = TRUE
-    ): int {
+    $event_id,
+    $contact_id = NULL,
+    array $class_list = [],
+    array $status_id_list = [],
+    bool $only_counted = TRUE
+  ): int {
     $event_id = (int) $event_id;
     $contact_id = (int) $contact_id;
 
     // compile query
     $class_list = array_intersect(['Positive', 'Pending', 'Negative', 'Waiting'], $class_list);
-    if (empty($class_list)) {
+    if ([] === $class_list) {
       $REGISTRATION_CLASSES = "('Positive', 'Pending', 'Negative', 'Waiting')";
     }
     else {
       $REGISTRATION_CLASSES = "('" . implode("','", $class_list) . "')";
     }
-    if (empty($status_id_list)) {
+    if ([] === $status_id_list) {
       $AND_STATUS_ID_IN_LIST = '';
     }
     else {
@@ -466,54 +463,63 @@ class CRM_Remoteevent_Registration {
     }
     if ($only_counted) {
       $AND_IS_COUNTED_CONDITION =
-                'AND status_type.is_counted = 1 AND option_value_participant_role.filter = 1';
+        'AND status_type.is_counted = 1 AND option_value_participant_role.filter = 1';
     }
     else {
       $AND_IS_COUNTED_CONDITION = '';
     }
 
-        // TODO: Include price options with participant count > 1.
+    // TODO: Include price options with participant count > 1.
 
-        $value_separator = CRM_Core_DAO::VALUE_SEPARATOR;
-        $query = "
-            SELECT COUNT(participant.id)
-            FROM civicrm_participant participant
-            LEFT JOIN civicrm_event  event
-                   ON event.id = participant.event_id
-            LEFT JOIN civicrm_participant_status_type status_type
-                   ON status_type.id = participant.status_id
-            INNER JOIN civicrm_option_value option_value_participant_role
-                    ON
-                        participant.role_id = option_value_participant_role.value
-                        OR participant.role_id LIKE CONCAT('%', option_value_participant_role.value, '{$value_separator}%')
-                        OR participant.role_id LIKE CONCAT('%{$value_separator}', option_value_participant_role.value, '%')
-                        OR participant.role_id LIKE CONCAT('%{$value_separator}', option_value_participant_role.value, '{$value_separator}%')
-            INNER JOIN civicrm_option_group option_group_participant_role
-                    ON option_group_participant_role.id = option_value_participant_role.option_group_id
-                    AND option_group_participant_role.name = 'participant_role'
-            WHERE status_type.class IN {$REGISTRATION_CLASSES}
-                  {$AND_IS_COUNTED_CONDITION}
-                  AND participant.event_id = {$event_id}
-                  {$AND_STATUS_ID_IN_LIST}
-                  {$AND_CONTACT_RESTRICTION}";
+    $value_separator = CRM_Core_DAO::VALUE_SEPARATOR;
+    // phpcs:disable Generic.Files.LineLength.TooLong
+    $query = <<<SQL
+      SELECT
+        IF(
+          -- If the line item count * the line item quantity is not 0
+          SUM(price_field_value.`count` * lineItem.qty),
+
+          -- then use the count * the quantity, ensuring each
+          -- actual participant record gets a result
+          SUM(price_field_value.`count` * lineItem.qty)
+            + COUNT(DISTINCT participant.id )
+            - COUNT(DISTINCT IF (price_field_value.`count`, participant.id, NULL)),
+
+          -- if the line item count is NULL or 0 then count the participants
+          COUNT(DISTINCT participant.id)
+        )
+      FROM civicrm_participant participant
+      LEFT JOIN civicrm_event event
+        ON event.id = participant.event_id
+      LEFT JOIN civicrm_participant_status_type status_type
+        ON status_type.id = participant.status_id
+      LEFT JOIN civicrm_line_item lineItem
+        ON
+          lineItem.entity_id = participant.id
+          AND  lineItem.entity_table = 'civicrm_participant'
+      LEFT JOIN civicrm_price_field_value price_field_value
+        ON
+          price_field_value.id = lineItem.price_field_value_id
+          AND price_field_value.`count`
+      INNER JOIN civicrm_option_value option_value_participant_role
+        ON
+          participant.role_id = option_value_participant_role.value
+          OR participant.role_id LIKE CONCAT('%', option_value_participant_role.value, '{$value_separator}%')
+          OR participant.role_id LIKE CONCAT('%{$value_separator}', option_value_participant_role.value, '%')
+          OR participant.role_id LIKE CONCAT('%{$value_separator}', option_value_participant_role.value, '{$value_separator}%')
+      INNER JOIN civicrm_option_group option_group_participant_role
+        ON
+          option_group_participant_role.id = option_value_participant_role.option_group_id
+          AND option_group_participant_role.name = 'participant_role'
+      WHERE status_type.class IN {$REGISTRATION_CLASSES}
+        {$AND_IS_COUNTED_CONDITION}
+        AND participant.event_id = {$event_id}
+        {$AND_STATUS_ID_IN_LIST}
+        {$AND_CONTACT_RESTRICTION}
+      SQL;
     // phpcs:enable
     return (int) CRM_Core_DAO::singleValueQuery($query);
   }
-
-  /**
-   * Create or identify the contact based on the collected data
-   *
-   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
-   *      event triggered by the RemoteParticipant.submit
-   */
-  public static function createContactXCM($registration) {
-    // get collected contact data
-    $contact_identification = $registration->getContactData();
-
-    // add contact type if it's missing
-    if (empty($contact_identification['contact_type'])) {
-      $contact_identification['contact_type'] = 'Individual';
-    }
 
     if (!$registration->isContactUpdated()) {
       if ($registration->getContactID()) {
@@ -659,242 +665,5 @@ class CRM_Remoteevent_Registration {
         }
       }
     }
-  }
-
-  /**
-   * Will calculate the participant status
-   *
-   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
-   *   registration event
-   */
-  public static function determineParticipantStatus($registration) {
-    // of there is already an issue, don't waste any more time on this
-    if ($registration->hasErrors()) {
-      return;
-    }
-
-    if ($registration->getParticipantID()) {
-      // there is already a registration identified
-      return;
-    }
-
-    // default status calculation
-    $participant_data = &$registration->getParticipantData();
-    $event_data = $registration->getEvent();
-
-    // check if this has a waiting list
-    if (empty($participant_data['participant_status_id'])) {
-      if (CRM_Remoteevent_RemoteEvent::hasActiveWaitingList($event_data['id'], $event_data)) {
-        $participant_data['participant_status_id'] = 'On waitlist';
-
-        if (!empty($event_data['waitlist_text'])) {
-          $registration->addStatus($event_data['waitlist_text']);
-        }
-        else {
-          $registration->addStatus(E::ts('You have been added to the waitlist.'));
-        }
-      }
-    }
-
-    // check if it registration requires approval
-    if (empty($participant_data['participant_status_id'])) {
-      if (!empty($event_data['requires_approval'])) {
-        // there is an active waiting list, see if need to get on it
-        $participant_data['participant_status_id'] = 'Awaiting approval';
-      }
-    }
-
-    // finally: the default status is Registered
-    if (empty($participant_data['participant_status_id'])) {
-      $participant_data['participant_status_id'] = 'Registered';
-    }
-  }
-
-  /**
-   * Will create a simple participant object
-   *
-   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
-   *   registration event
-   */
-  public static function createParticipant($registration) {
-    // of there is already an issue, don't waste any more time on this
-    if ($registration->hasErrors()) {
-      return;
-    }
-
-    // let's look into this
-    $participant_data = &$registration->getParticipantData();
-
-    if ($registration->getParticipantID()) {
-      // this is updating an existing participant
-      $participant_data['id'] = $registration->getParticipantID();
-      if (!$registration->isParticipantUpdated()) {
-        $participant_data['force_trigger_eventmessage'] = 1;
-      }
-
-    }
-    else {
-      // we're creating an all new participant
-      if (!isset($participant_data['contact_id'])) {
-        $participant_data['contact_id'] = $registration->getContactID();
-      }
-    }
-
-    // Modify Participant Data Event here. This can be used to maybe manually update/set participant data
-    $update_participant_event = new UpdateParticipantEvent($participant_data);
-    // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
-    Civi::dispatcher()->dispatch(UpdateParticipantEvent::NAME, $update_participant_event);
-    $participant_data = $update_participant_event->get_participant_data();
-
-    // run create/update
-    CRM_Remoteevent_CustomData::resolveCustomFields($participant_data);
-    $creation = civicrm_api3('Participant', 'create', $participant_data);
-    $registration->setParticipantUpdated();
-    $participant = civicrm_api3('Participant', 'getsingle', ['id' => $creation['id']]);
-    CRM_Remoteevent_CustomData::labelCustomFields($participant);
-    $registration->setParticipant($participant);
-
-    // invalidate caches
-    self::invalidateRegistrationCache($participant_data['contact_id'], $participant_data['event_id']);
-    CRM_Remoteevent_RemoteEvent::invalidateRemoteEvent($registration->getEventID());
-  }
-
-  public static function registerAdditionalParticipants(RegistrationEvent $registration): void {
-    if ($registration->hasErrors() || [] === $registration->getAdditionalParticipantsData()) {
-      return;
-    }
-
-    $additionalContactsData = $registration->getAdditionalContactsData();
-    $additionalParticipantsData = $registration->getAdditionalParticipantsData();
-
-    foreach ($additionalContactsData as $participantNo => $contactData) {
-      CRM_Remoteevent_CustomData::resolveCustomFields($contactData);
-      $match = civicrm_api3('Contact', 'getorcreate', $contactData);
-      if (!isset($match['id'])) {
-        throw new \RuntimeException('Contact for additional participant could not be identified or created.');
-      }
-
-      $additionalParticipantsData[$participantNo]['contact_id']
-        = $additionalContactsData[$participantNo]['id'] = $contactData['id'] = $match['id'];
-
-      // Check for existing participants for the identified contact.
-      $cannotRegisterReason = CRM_Remoteevent_Registration::cannotRegister(
-        $registration->getEventID(),
-        $contactData['id'],
-        $registration->getEvent()
-      );
-      if ($cannotRegisterReason) {
-        $registration->addError(
-        E::ts('Additional participant %1: %2', [
-          1 => $participantNo,
-          2 => $cannotRegisterReason,
-        ])
-        );
-      }
-      // Do not register participants yet, as there might be reasons for not
-      // registering, and we want to collect all of them first.
-    }
-
-    $registration->setAdditionalContactsData($additionalContactsData);
-
-    // Abort if any additional participant can't be registered.
-    if ($registration->hasErrors()) {
-      return;
-    }
-
-    // Create additional participants.
-    foreach ($additionalParticipantsData as &$participantData) {
-      $participantData['registered_by_id'] = $registration->getParticipantID();
-      $participantData['register_date'] = date('Y-m-d H:i');
-      $participantRegistered = Participant::create(FALSE)
-        ->setValues($participantData)
-        ->execute()
-        ->single();
-
-      $participantData += $participantRegistered;
-    }
-
-    $registration->setAdditionalParticipantsData($additionalParticipantsData);
-  }
-
-  /**
-   * Get a (cached version) of ParticipantStatusType.get
-   */
-  public static function getParticipantStatusList() {
-    static $status_list = NULL;
-    if ($status_list === NULL) {
-      $status_list = [];
-      $query = civicrm_api3('ParticipantStatusType', 'get', ['option.limit' => 0]);
-      foreach ($query['values'] as $status) {
-        $status_list[$status['id']] = $status;
-      }
-    }
-    return $status_list;
-  }
-
-  /**
-   * Get a the class of the given status ID
-   *
-   * @param integer $participant_status_id
-   *   the status id
-   *
-   * @return string
-   *   class name: 'Positive', 'Negative', 'Pending'...
-   */
-  public static function getParticipantStatusClass($participant_status_id) {
-    $status_list = self::getParticipantStatusList();
-    $status = $status_list[$participant_status_id];
-    return $status['class'];
-  }
-
-  /**
-   * Get a the name of the given status ID
-   *
-   * @param integer $participant_status_id
-   *   the status id
-   *
-   * @return string
-   *   status (internal) name: 'Registered', 'Attended', ...
-   */
-  public static function getParticipantStatusName($participant_status_id) {
-    $status_list = self::getParticipantStatusList();
-    $status = $status_list[$participant_status_id];
-    return $status['name'];
-  }
-
-  /**
-   * Add the GTAC data to the get_form results
-   *
-   * @param \Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent $get_form_results
-   *      event triggered by the RemoteParticipant.get_form API call
-   */
-  public static function addGtacField($get_form_results) {
-    $event = $get_form_results->getEvent();
-    if (!empty($event['event_remote_registration.remote_registration_gtac'])) {
-      $l10n = $get_form_results->getLocalisation();
-      $get_form_results->addFields([
-        'gtacs' => [
-          'type'        => 'fieldset',
-          'name'        => 'gtacs',
-          'label'       => $l10n->ts('General Terms and Conditions'),
-      // this should be at the end
-          'weight'      => 500,
-        ],
-        'gtac' => [
-          'name' => 'gtac',
-          'type' => 'Checkbox',
-          'validation' => '',
-          'weight' => 100,
-          'required' => 1,
-          'label' => $l10n->ts('I accept the following terms and conditions'),
-          'description' => '',
-          'parent' => 'gtacs',
-          'suffix' => $event['event_remote_registration.remote_registration_gtac'],
-          'suffix_display' => 'inline',
-          'suffix_dialog_label' => $l10n->ts('Details'),
-        ],
-      ]);
-    }
-  }
 
 }

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -587,41 +587,41 @@ class CRM_Remoteevent_Registration {
       return;
     }
 
-    // now, after the contact has been identified, make sure (s)he's not already registered
-    $cant_register_reason = CRM_Remoteevent_Registration::cannotRegister(
-      $registration->getEventID(),
-      $registration->getContactID(),
-      $registration->getEvent()
-    );
-    if ($cant_register_reason) {
-      $registration->addError($cant_register_reason);
+    public static function createOrder(RegistrationEvent $registration): void {
+      $event = $registration->getEvent();
+      if (
+        (bool) $event['is_monetary']
+        && class_exists('\Civi\Api4\Order')
+      ) {
+        $order = \Civi\Api4\Order::create(FALSE)
+          ->setContributionValues([
+            'contact_id' => $registration->getContactID(),
+            'financial_type_id' => $event['financial_type_id'],
+          ]);
+        foreach ($registration->getPriceFieldValues() as $value) {
+          $order->addLineItem([
+            'entity_table' => 'civicrm_participant',
+            'entity_id' => $value['participant_id'],
+            'price_field_value_id' => $value['price_field_value_id'],
+            'qty' => $value['qty']
+          ]);
+        }
+        $order->execute();
+      }
     }
-  }
 
-  /**
-   * If there is already an existing participant,
-   *  process the confirmation
-   *
-   * @param \Civi\RemoteParticipant\Event\RegistrationEvent $registration
-   *   registration event
-   */
-  public static function confirmExistingParticipant($registration) {
-    // of there is already an issue, don't waste any more time on this
-    if ($registration->hasErrors()) {
-      return;
-    }
-
-    $participant_id = $registration->getParticipantID();
-    $submission = $registration->getSubmission();
-    if (isset($submission['confirm'])) {
-      if ($participant_id) {
-        // there is already a (pre-existing) participant
-        //   ... and the 'confirm' flag has been submitted
-        //   then: update the participant right away
-        $new_status = '';
-        if (empty($submission['confirm'])) {
-          // participant want's out
-          $new_status = 'Rejected';
+    /**
+     * Get a (cached version) of ParticipantStatusType.get
+     */
+    public static function getParticipantStatusList()
+    {
+        static $status_list = null;
+        if ($status_list === null) {
+            $status_list = [];
+            $query = civicrm_api3('ParticipantStatusType', 'get', ['option.limit' => 0]);
+            foreach ($query['values'] as $status) {
+                $status_list[$status['id']] = $status;
+            }
         }
         else {
           // participant wants to confirm

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -16,7 +16,6 @@
 declare(strict_types = 1);
 
 use Civi\Api4\Participant;
-use Civi\RemoteParticipant\Event\GetCreateParticipantFormEvent;
 use Civi\RemoteParticipant\Event\RegistrationEvent;
 use Civi\RemoteParticipant\Event\UpdateParticipantEvent;
 use CRM_Remoteevent_ExtensionUtil as E;
@@ -126,12 +125,13 @@ class CRM_Remoteevent_Registration {
 
   /**
    * Get a list of participant objects
-     *
-     * @param integer $event_id
-     *   the event
-     *
-     * @param integer $contact_id
-     *   the contact
+   *
+   * @param integer $contact_id
+   *   the contact
+   *
+   * @param integer $event_id
+   *   the event
+   *
    */
   public static function invalidateRegistrationCache($contact_id, $event_id) {
     // unset the registration data
@@ -204,7 +204,8 @@ class CRM_Remoteevent_Registration {
       if ($registered_count >= $event_data['max_participants']) {
         if (empty($event_data['event_full_text'])) {
           return E::ts('Event is booked out');
-        } else {
+        }
+        else {
           return $event_data['event_full_text'];
         }
       }
@@ -298,13 +299,15 @@ class CRM_Remoteevent_Registration {
     if (empty($event_data['selfcancelxfer_time'])) {
       // no restrictions
       return TRUE;
-    } else {
+    }
+    else {
       $min_seconds_before_start = 60 * 60 * (int) $event_data['selfcancelxfer_time'];
       $current_seconds_before_start = strtotime($event_data['start_date']) - strtotime('now');
       if ($current_seconds_before_start > $min_seconds_before_start) {
         // we can still cancel
         return TRUE;
-      } else {
+      }
+      else {
         // we're too close to the event starting date
         return FALSE;
       }
@@ -389,7 +392,8 @@ class CRM_Remoteevent_Registration {
     if (!empty($event_data['enabled_profiles'])) {
       $enabled_profiles = explode(',', $event_data['enabled_profiles']);
       return in_array('OneClick', $enabled_profiles);
-    } else {
+    }
+    else {
       return FALSE;
     }
   }
@@ -552,13 +556,15 @@ class CRM_Remoteevent_Registration {
         CRM_Remoteevent_CustomData::resolveCustomFields($contact_identification);
         $match = civicrm_api3('Contact', 'getorcreate', $contact_identification);
 
-      } catch (Exception $ex) {
+      }
+      catch (Exception $ex) {
         if (empty($contact_identification['id'])) {
           // no contact ID given -> there must be some data missing
           throw new Exception(
           E::ts("Couldn't find or create contact: ") . $ex->getMessage());
 
-        } else {
+        }
+        else {
           // the contact ID ws passed, but it still failed.
           // first: check if options.match_contact_id is set
           $profile_name = $contact_identification['xcm_profile'];
@@ -568,7 +574,8 @@ class CRM_Remoteevent_Registration {
               // phpcs:ignore Generic.Files.LineLength.TooLong
               "RemoteEvent: maybe you should activate the 'Match contacts by contact ID' option for your '{$profile_name}' profile, so that contact updates could also be applied if the participant is only identified by ID."
             );
-          } else {
+          }
+          else {
             throw new Exception(E::ts('Error while updating contact %1: %2', [
               1 => $contact_identification['id'],
               2 => $ex->getMessage(),
@@ -645,14 +652,16 @@ class CRM_Remoteevent_Registration {
         if (empty($submission['confirm'])) {
           // participant want's out
           $new_status = 'Rejected';
-        } else {
+        }
+        else {
           // participant wants to confirm
           if (CRM_Remoteevent_RemoteEvent::hasActiveWaitingList(
                 $registration->getEventID(),
                 $registration->getEvent()
             )) {
             $new_status = 'On waitlist';
-          } else {
+          }
+          else {
             $new_status = 'Registered';
           }
         }
@@ -669,7 +678,8 @@ class CRM_Remoteevent_Registration {
         // mark as updated to avoid additional calls
         // see also: https://github.com/systopia/de.systopia.remoteevent/issues/19
         $registration->setParticipantUpdated();
-      } else {
+      }
+      else {
         // there is no pre-existing participant, just add to the general to-be-created one
         if (empty($submission['confirm'])) {
           $participant = &$registration->getParticipantData();
@@ -707,7 +717,8 @@ class CRM_Remoteevent_Registration {
 
         if (!empty($event_data['waitlist_text'])) {
           $registration->addStatus($event_data['waitlist_text']);
-        } else {
+        }
+        else {
           $registration->addStatus(E::ts('You have been added to the waitlist.'));
         }
       }
@@ -749,7 +760,8 @@ class CRM_Remoteevent_Registration {
         $participant_data['force_trigger_eventmessage'] = 1;
       }
 
-        } else {
+    }
+    else {
       // we're creating an all new participant
       if (!isset($participant_data['contact_id'])) {
         $participant_data['contact_id'] = $registration->getContactID();
@@ -792,7 +804,7 @@ class CRM_Remoteevent_Registration {
 
       $additionalParticipantsData[$participantNo]['contact_id']
         = $additionalContactsData[$participantNo]['id']
-        = $contactData['id'] = $match['id'];
+          = $contactData['id'] = $match['id'];
 
       // Check for existing participants for the identified contact.
       $cannotRegisterReason = CRM_Remoteevent_Registration::cannotRegister(
@@ -844,7 +856,7 @@ class CRM_Remoteevent_Registration {
           'payment_instrument_id' => static::getPaymentInstrumentForPaymentMethod(
             $registration->getSubmittedValue('payment_method'),
             $event
-          )
+          ),
         ]);
       foreach ($registration->getPriceFieldValues() as $value) {
         $order->addLineItem([
@@ -1001,12 +1013,13 @@ class CRM_Remoteevent_Registration {
           'weight' => 100,
           'required' => 1,
           'label' => $l10n->ts('I accept the following terms and conditions'),
-          'description' => '', //$l10n->ts("You have to accept the terms and conditions to participate in this event"),
+          /** $l10n->ts("You have to accept the terms and conditions to participate in this event"), */
+          'description' => '',
           'parent' => 'gtacs',
           'suffix' => $event['event_remote_registration.remote_registration_gtac'],
           'suffix_display' => 'inline',
           'suffix_dialog_label' => $l10n->ts('Details'),
-        ]
+        ],
       ]);
     }
   }

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -599,6 +599,10 @@ class CRM_Remoteevent_Registration {
           ->setContributionValues([
             'contact_id' => $registration->getContactID(),
             'financial_type_id' => (int) $event['financial_type_id'],
+            'payment_instrument_id' => static::getPaymentInstrumentForPaymentMethod(
+              $registration->getSubmittedValue('payment_method'),
+              $event
+            )
           ]);
         foreach ($registration->getPriceFieldValues() as $value) {
           $order->addLineItem([
@@ -609,7 +613,79 @@ class CRM_Remoteevent_Registration {
             'qty' => $value['qty'],
           ]);
         }
-        $order->execute();
+        try {
+          $orderResult = $order
+            ->execute()
+            ->single();
+          $registration->setOrderData($orderResult);
+        }
+        catch (CRM_Core_Exception $exception) {
+          $registration->addError(E::ts('Could not register order.'));
+        }
+      }
+    }
+
+  /**
+   * @phpstan-param array{
+   *   id: int,
+   *   currency: string,
+   *   fee_label: string,
+   *   is_monetary: int,
+   * } $event
+   */
+    public static function getPaymentInstrumentForPaymentMethod(string $paymentMethod, array $event): int {
+      switch ($paymentMethod) {
+        case 'pay_later':
+          // TODO: Make payment method for "Pay later" configurable per event.
+          return (int) \Civi\Api4\OptionValue::get(FALSE)
+            ->addSelect('value')
+            ->addWhere('option_group_id.name', '=', 'payment_instrument')
+            ->addWhere('name', '=', 'EFT')
+            ->execute()['value'];
+
+        case 'sepa':
+          // Use OOFF payment instrument from creditor.
+          // TODO: Make creditor configurable per event.
+          return (int) \CRM_Sepa_Logic_Settings::defaultCreditor()->pi_ooff;
+      }
+    }
+
+    public static function createPayment(RegistrationEvent $registration): void {
+      $event = $registration->getEvent();
+      if ((bool) $event['is_monetary']) {
+        $order = $registration->getOrderData();
+
+        switch ($registration->getSubmittedValue('payment_method')) {
+          case 'pay_later':
+            // Nothing to do here, there is already a pending contribution.
+            break;
+
+          case 'sepa':
+            $mandate = \Civi\Api4\SepaMandate::create(FALSE)
+              ->addValue('creditor_id', NULL)
+              ->addValue('type', 'OOFF')
+              ->addValue('iban', $registration->getSubmittedValue('payment_method_sepa_iban'))
+              ->addValue('bic', $registration->getSubmittedValue('payment_method_sepa_bic'))
+              ->addValue('status', 'OOFF')
+              // Reference is given a default when empty(), but is a required field, thus passing 0.
+              // TODO: Adjust CiviSEPA to not make the API parameter required if there is a default, and do not pass a
+              //       a value once that's done.
+              ->addValue('reference', 0)
+              ->addValue('entity_table', 'civicrm_contribution')
+              ->addValue('entity_id', $order['id'])
+              ->addValue('contact_id', $registration->getContactID())
+              ->addValue('currency', $event['currency'])
+              ->addValue('date', $order['receive_date'])
+              ->addValue('creation_date', $order['receive_date'])
+              ->addValue('validation_date', $order['receive_date'])
+              ->execute();
+            break;
+
+          default:
+            // TODO: Register submitted payment (API to be defined; must include the amount and the date, possibly a
+            //       transaction ID, etc.) using \Civi\Api4\Payment::create().
+            break;
+        }
       }
     }
 

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -561,8 +561,10 @@ class CRM_Remoteevent_Registration {
         if (empty($contact_identification['id'])) {
           // no contact ID given -> there must be some data missing
           throw new Exception(
-          E::ts("Couldn't find or create contact: ") . $ex->getMessage());
-
+            E::ts("Couldn't find or create contact: ") . $ex->getMessage(),
+            0,
+            $ex
+          );
         }
         else {
           // the contact ID ws passed, but it still failed.

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -469,8 +469,6 @@ class CRM_Remoteevent_Registration {
       $AND_IS_COUNTED_CONDITION = '';
     }
 
-    // TODO: Include price options with participant count > 1.
-
     $value_separator = CRM_Core_DAO::VALUE_SEPARATOR;
     // phpcs:disable Generic.Files.LineLength.TooLong
     $query = <<<SQL

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -472,9 +472,10 @@ class CRM_Remoteevent_Registration {
       $AND_IS_COUNTED_CONDITION = '';
     }
 
-    $value_separator = CRM_Core_DAO::VALUE_SEPARATOR;
-    // phpcs:disable Generic.Files.LineLength.TooLong
-    $query = "
+        // TODO: Include price options with participant count > 1.
+
+        $value_separator = CRM_Core_DAO::VALUE_SEPARATOR;
+        $query = "
             SELECT COUNT(participant.id)
             FROM civicrm_participant participant
             LEFT JOIN civicrm_event  event

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -482,7 +482,7 @@ class CRM_Remoteevent_Registration {
           -- then use the count * the quantity, ensuring each
           -- actual participant record gets a result
           SUM(price_field_value.`count` * lineItem.qty)
-            + COUNT(DISTINCT participant.id )
+            + COUNT(DISTINCT participant.id)
             - COUNT(DISTINCT IF (price_field_value.`count`, participant.id, NULL)),
 
           -- if the line item count is NULL or 0 then count the participants

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -179,6 +179,31 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     // @phpstan-ignore method.deprecated
     $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
 
+    public static function getPriceFields(array $event): array {
+      return \Civi\Api4\Event::get(FALSE)
+        ->addSelect('price_field.*')
+        ->addJoin(
+          'PriceSetEntity AS price_set_entity',
+          'INNER',
+          ['price_set_entity.entity_table', '=', '"civicrm_event"'],
+          ['price_set_entity.entity_id', '=', 'id']
+        )
+        ->addJoin(
+          'PriceSet AS price_set',
+          'INNER',
+          ['price_set.id', '=', 'price_set_entity.price_set_id'],
+          ['price_set.is_active', '=', 1]
+        )
+        ->addJoin(
+          'PriceField AS price_field',
+          'LEFT',
+          ['price_field.price_set_id', '=', 'price_set.id']
+        )
+        ->addWhere('id', '=', $event['id'])
+        ->execute()
+        ->getArrayCopy();
+    }
+
     /**
      * @param array $event
      * @param string|null $locale
@@ -186,7 +211,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
      * @return array<string,array<string,mixed>>
      * @throws \CRM_Core_Exception
      */
-    public function getPriceFields(array $event, ?string $locale = NULL): array
+    public function getProfilePriceFields(array $event, ?string $locale = NULL): array
     {
         $fields = [];
 
@@ -194,28 +219,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
             return $fields;
         }
 
-        $priceFields = \Civi\Api4\Event::get(FALSE)
-            ->addSelect('price_field.*')
-            ->addJoin(
-                'PriceSetEntity AS price_set_entity',
-                'INNER',
-                ['price_set_entity.entity_table', '=', '"civicrm_event"'],
-                ['price_set_entity.entity_id', '=', 'id']
-            )
-            ->addJoin(
-                'PriceSet AS price_set',
-                'INNER',
-                ['price_set.id', '=', 'price_set_entity.price_set_id'],
-                ['price_set.is_active', '=', 1]
-            )
-            ->addJoin(
-                'PriceField AS price_field',
-                'LEFT',
-                ['price_field.price_set_id', '=', 'price_set.id']
-            )
-            ->addWhere('id', '=', $event['id'])
-            ->execute();
-
+        $priceFields = self::getPriceFields($event);
         if (count($priceFields) === 0) {
            return $fields;
         }
@@ -236,17 +240,29 @@ abstract class CRM_Remoteevent_RegistrationProfile {
             $field = [
                 // TODO: Validate types.
                 'type' => $priceField['price_field.html_type'],
-                'name' => $priceField['price_field.name'],
+                'name' => 'price_' . $priceField['price_field.name'],
                 // TODO: Localize label with given $locale.
                 'label' => $priceField['price_field.label'],
                 'weight' => $priceField['price_field.weight'],
                 'required' => (bool) $priceField['price_field.is_required'],
                 'parent' => 'price',
-                'options' => $priceFieldValues->column('label'),
             ];
+            if ($priceField['price_field.is_enter_qty']) {
+                // Append price per unit.
+                $field['label'] .= sprintf(
+                  ' (%s)',
+                  CRM_Utils_Money::format(
+                    $priceFieldValues->first()['amount'],
+                    $event['currency']
+                  )
+                );
+            }
+            else {
+                $field['options'] = $priceFieldValues->column('label');
+            }
 
             // Append price field value amounts in option labels.
-            if ($priceField['price_field.is_display_amounts']) {
+            if (isset($field['options']) && $priceField['price_field.is_display_amounts']) {
                 array_walk($field['options'], function(&$label, $id, $context) {
                     $label .= sprintf(
                         ' (%s)',
@@ -272,7 +288,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
                 $field['suffix_display'] = 'inline';
             }
 
-            // TODO: Ids the price field name unique across all price fields for
+            // TODO: Is the price field name unique across all price fields for
             //       this event?
             $fields['price_' . $priceField['price_field.name']] = $field;
         }
@@ -292,7 +308,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
                 $event['event_remote_registration.remote_registration_additional_participants_profile']
             );
             $additional_fields = $additional_participants_profile->getFields($locale);
-            $additional_fields += $additional_participants_profile->getPriceFields($event, $locale);
+            $additional_fields += $additional_participants_profile->getProfilePriceFields($event, $locale);
             $fields['additional_participants'] = [
                 'type' => 'fieldset',
                 'name' => 'additional_participants',
@@ -414,7 +430,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
 
         // Validate price fields.
         if ((bool) $event['is_monetary']) {
-            foreach ($this->validatePriceFields($event, $data) as $field_name => $error) {
+            foreach ($this->validatePriceFields($event, $data, $l10n) as $field_name => $error) {
                 $validationEvent->addValidationError($field_name, $error);
             }
         }
@@ -433,7 +449,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     protected function validatePriceFields(array $event, array $submission, CRM_Remoteevent_Localisation $l10n): array
     {
         $errors = [];
-        foreach ($this->getPriceFields($event) as $priceField) {
+        foreach ($this->getProfilePriceFields($event) as $priceField) {
             // TODO: Validate price field values.
         }
         return $errors;
@@ -563,7 +579,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         $locale = $get_form_results->getLocale();
         $fields = $profile->getFields($locale);
         if ('create' === $get_form_results->getContext()) {
-          $fields += $profile->getPriceFields($event, $locale);
+          $fields += $profile->getProfilePriceFields($event, $locale);
           $fields += $profile->getAdditionalParticipantsFields($event, NULL, $locale);
         }
       }

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -20,7 +20,6 @@ use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
 use CRM_Remoteevent_ExtensionUtil as E;
 
 use Civi\Api4\Participant;
-use Civi\RemoteEvent as RemoteEvent;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 use Civi\RemoteParticipant\Event\ValidateEvent;
@@ -288,7 +287,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         $event['event_remote_registration.remote_registration_additional_participants_profile']
       );
       $additional_fields = $additional_participants_profile->getFields($locale);
-            $additional_fields += self::getProfilePriceFields($event, $locale);
+      $additional_fields += self::getProfilePriceFields($event, $locale);
       $fields['additional_participants'] = [
         'type' => 'fieldset',
         'name' => 'additional_participants',
@@ -419,6 +418,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     }
   }
 
+  // phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
   protected function validateFieldValues(ValidateEvent $validationEvent): void {
     $data = $validationEvent->getSubmission();
     $event = $validationEvent->getEvent();
@@ -471,6 +471,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
   /**
    * @throws \CRM_Core_Exception
    */
+  // phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
   protected function validatePriceFields(ValidateEvent $validationEvent): void {
     /** @phpstan-var array<string, mixed> $event*/
     $event = $validationEvent->getEvent();
@@ -589,7 +590,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     if (preg_match('/^custom_/', $field_key)
         || preg_match('/^\w+[.]\w+$/', $field_key)) {
       return ['Contact', 'Participant'];
-    } else {
+    }
+    else {
       return ['Contact'];
     }
   }
@@ -622,11 +624,11 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     $this->adjustContactData($contact_data);
   }
 
-  /*************************************************************
-   *                HELPER / INFRASTRUCTURE                   **
-   *************************************************************/
+  //*************************************************************
+  //*                HELPER / INFRASTRUCTURE                   **
+  //*************************************************************
 
-    /**
+  /**
    * Add the profile data to the get_form results
    *
    * @param \Civi\RemoteEvent $remote_event
@@ -681,8 +683,6 @@ abstract class CRM_Remoteevent_RegistrationProfile {
    * @param \Civi\RemoteParticipant\Event\GetParticipantFormEventBase $get_form_results
    *   event triggered by the RemoteParticipant.get_form API call
    *
-   * @return array|null
-   *   returns API error if there is an issue
    */
   public static function addProfileData($get_form_results) {
     // simply add the fields from the profile
@@ -817,7 +817,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
       $default_profile_name = $event['event_remote_registration.remote_registration_default_profile'];
       if (isset($profiles[$default_profile_name])) {
         $event['default_profile'] = $default_profile_name;
-      } else {
+      }
+      else {
         $event['default_profile'] = '';
       }
       unset($event['event_remote_registration.remote_registration_default_profile']);
@@ -834,7 +835,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
       $default_profile_name = $event['event_remote_registration.remote_registration_default_update_profile'];
       if (isset($profiles[$default_profile_name])) {
         $event['default_update_profile'] = $default_profile_name;
-      } else {
+      }
+      else {
         $event['default_update_profile'] = '';
       }
       unset($event['event_remote_registration.remote_registration_default_update_profile']);
@@ -846,7 +848,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
       $enabled_profile_names = array_intersect($enabled_profiles, array_keys($profiles));
       $event['enabled_update_profiles'] = implode(',', $enabled_profile_names);
       unset($event['event_remote_registration.remote_registration_update_profiles']);
-    } else {
+    }
+    else {
       $event['enabled_update_profiles'] = [];
     }
 
@@ -872,7 +875,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
    * @param array $data
    *   input data
    *
-   * @param string mode
+   * @param string $mode
    *   'exception' (default) throws an exception if some of the data is invalid,
    *   'filter' will simply drop those
    *
@@ -891,7 +894,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         $value = $data[$field_key];
         if ($this->validateFieldValue($field_spec, $value)) {
           $return_values[$field_key] = $value;
-        } else {
+        }
+        else {
           if ($mode == 'exception') {
             throw new Exception(
             E::ts(
@@ -949,7 +953,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         try {
           CRM_Utils_Type::validate($value, $validation);
           return TRUE;
-        } catch (Exception $ex) {
+        }
+        catch (Exception $ex) {
           return FALSE;
         }
 
@@ -958,7 +963,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         if (substr($validation, 0, 6) == 'regex:') {
           if (NULL !== $value && strlen($value) > 0) {
             return preg_match(substr($validation, 6), $value) > 0;
-          } else {
+          }
+          else {
             return TRUE;
           }
         }
@@ -1106,7 +1112,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
         ]);
         $contact_data += $legacy_contact_data;
         ParticipantFormEventUtil::mapToPrefill($contact_data, $attribute_mapping, $resultsEvent, $value_callbacks);
-      } catch (CRM_Core_Exception $ex) {
+      }
+      catch (CRM_Core_Exception $ex) {
         // @ignoreException
         // there is no (unique) primary email
       }

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -212,10 +212,9 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     }
 
     /**
-     * @param array $event
-     * @param string|null $locale
+     * @phpstan-param array<string, mixed> $event
      *
-     * @return array<string,array<string,mixed>>
+     * @phpstan-return array<string, array<string, mixed>>
      * @throws \CRM_Core_Exception
      */
     public function getProfilePriceFields(array $event, ?string $locale = NULL): array
@@ -444,23 +443,37 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     }
 
   /**
-   * @param array $event
-   * @param array $submission
-   * @param \CRM_Remoteevent_Localisation $l10n
+   * @phpstan-param array<string, mixed> $event
+   * @phpstan-param array<string, mixed> $submission
    *
-   * @return array<string, string>
+   * @phpstan-return array<string, string>
    *   An array with field names as keys and corresponding localised error
    *   messages as values.
    * @throws \CRM_Core_Exception
    */
-    protected function validatePriceFields(array $event, array $submission, CRM_Remoteevent_Localisation $l10n): array
-    {
-        $errors = [];
-        foreach ($this->getProfilePriceFields($event) as $priceField) {
-            // TODO: Validate price field values.
+  protected function validatePriceFields(array $event, array $submission, CRM_Remoteevent_Localisation $l10n): array {
+    $errors = [];
+    foreach ($this->getProfilePriceFields($event) as $fieldName => $priceField) {
+      // Validate price field values inside the "price" fieldset.
+      if ('price' === $priceField['parent']) {
+        // Validate price field value is a valid options.
+        if (
+          isset($priceField['options'])
+          && !array_key_exists($submission[$fieldName], $priceField['options'])
+        ) {
+          $errors[$fieldName] = $l10n->ts('Invalid value');
         }
-        return $errors;
+
+        // Validate quantity being numeric.
+        elseif (!is_numeric($submission[$fieldName])) {
+          $errors[$fieldName] = $l10n->ts('Quantity must be numeric');
+        }
+
+        // TODO: Validate availability of price options.
+      }
     }
+    return $errors;
+  }
 
     /**
      * This function will tell you which entity/entities the given field

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -188,11 +188,16 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
 
   /**
-   * @phpstan-param array<string, mixed> $event
+   * @phpstan-param array{
+   *   id: int,
+   *   currency: string,
+   *   fee_label: string,
+   *   is_monetary: int
+   * } $event
    *
    * @param string|null $locale
    *
-   * @return array
+   * @phpstan-return array<string, array<string, mixed>>
    * @throws \CRM_Core_Exception
    */
   public static function getProfilePriceFields(array $event, ?string $locale = NULL): array {
@@ -230,7 +235,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         'required' => (bool) $priceField['price_field.is_required'],
         'parent' => 'price',
       ];
-      if ($priceField['price_field.is_enter_qty']) {
+      if ((bool) $priceField['price_field.is_enter_qty']) {
         // Append price per unit.
         $field['label'] .= sprintf(
           ' (%s)',
@@ -242,23 +247,23 @@ abstract class CRM_Remoteevent_RegistrationProfile
       }
       else {
         $field['options'] = $priceFieldValues->column('label');
-      }
 
-      // Append price field value amounts in option labels.
-      if (isset($field['options']) && $priceField['price_field.is_display_amounts']) {
-        array_walk(
-          $field['options'],
-          function(&$label, $id, $context) {
-            $label .= sprintf(
-              ' (%s)',
-              CRM_Utils_Money::format(
-                $context['priceFieldValues'][$id]['amount'],
-                $context['event']['currency']
-              )
-            );
-          },
-          ['priceFieldValues' => $priceFieldValues, 'event' => $event]
-        );
+        // Append price field value amounts in option labels.
+        if ((bool) $priceField['price_field.is_display_amounts']) {
+          array_walk(
+            $field['options'],
+            function(&$label, $id, $context) {
+              $label .= sprintf(
+                ' (%s)',
+                CRM_Utils_Money::format(
+                  $context['priceFieldValues'][$id]['amount'],
+                  $context['event']['currency']
+                )
+              );
+            },
+            ['priceFieldValues' => $priceFieldValues, 'event' => $event]
+          );
+        }
       }
 
       // Add prefixed help text.

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -219,7 +219,14 @@ abstract class CRM_Remoteevent_RegistrationProfile
       // TODO: Is this configurable option localizable?
       'label' => $event['fee_label'],
     ];
+
+    $maxWeight = 0;
+    $hasRequiredPriceFields = FALSE;
+
     foreach ($priceFields as $priceField) {
+      $maxWeight = max($maxWeight, $priceField['price_field.weight']);
+      $hasRequiredPriceFields = $hasRequiredPriceFields || (bool) $priceField['price_field.is_required'];
+
       $priceFieldValues = \Civi\Api4\PriceFieldValue::get(FALSE)
         ->addSelect('id', 'label', 'amount')
         ->addWhere('price_field_id', '=', $priceField['price_field.id'])
@@ -284,7 +291,92 @@ abstract class CRM_Remoteevent_RegistrationProfile
       $fields['price_' . $priceField['price_field.name']] = $field;
     }
 
+    $fields += static::getPaymentProcessorFields($event, $locale, $maxWeight, $hasRequiredPriceFields);
+
     return $fields;
+  }
+
+  public static function getPaymentProcessorFields(
+    array $event,
+    ?string $locale = NULL,
+    int $maxWeight = 0,
+    bool $paymentRequired = FALSE
+  ): array {
+    $fields = [];
+    $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
+
+    if (is_numeric($event['payment_processor']) || is_array($event['payment_processor'])) {
+      $fields['payment'] = [
+        'type' => 'fieldset',
+        'name' => 'payment',
+        'label' => $l10n->ts('Payment'),
+        'parent' => 'price',
+        'weight' => $maxWeight++,
+      ];
+      $fields['payment_processor'] = [
+        'type' => 'Select',
+        'name' => 'payment_processor',
+        'label' => $l10n->ts('Payment Method'),
+        'options' => [],
+        'required' => $paymentRequired,
+        'parent' => 'payment',
+        'weight' => 0,
+      ];
+
+      if ((bool) $event['is_pay_later']) {
+        $fields['payment_processor']['options'][0] = $event['pay_later_text'];
+        // TODO: Add notes from $event['pay_later_receipt'].
+      }
+
+      foreach ((array) $event['payment_processor'] as $paymentProcessorId) {
+        $paymentProcessor = \Civi\Api4\PaymentProcessor::get(FALSE)
+          ->addWhere('id', '=', $paymentProcessorId)
+          ->execute()
+          ->single();
+        $paymentProcessorObject = \Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
+
+        $fields['payment_processor']['options'][$paymentProcessorId] = $l10n->ts(
+          $paymentProcessorObject->getPaymentProcessor()['frontend_title']
+        );
+
+        $paymentProcessorFormFields = array_intersect_key(
+          $paymentProcessorObject->getPaymentFormFieldsMetadata(),
+          array_flip($paymentProcessorObject->getPaymentFormFields())
+        );
+        foreach ($paymentProcessorFormFields as $paymentProcessorField) {
+          $fieldName = 'payment_processor_' . $paymentProcessorId . '_' . $paymentProcessorField['name'];
+          $fields[$fieldName] = [
+            'type' => self::getQuickFormType($paymentProcessorField['htmlType']),
+            'name' => $fieldName,
+            'label' => $paymentProcessorField['title'],
+            'required' => (bool) $paymentProcessorField['is_required'],
+            'maxlength' => $paymentProcessorField['attributes']['maxlength'] ?? NULL,
+            'parent' => 'payment_processor',
+            'weight' => 1,
+            'dependencies' => [
+              [
+                'command' => 'hide',
+                'dependee_field' => 'payment_processor',
+                'dependee_value' => $paymentProcessorId,
+              ],
+            ],
+          ];
+        }
+      }
+    }
+
+    return $fields;
+  }
+
+  public static function getQuickFormType(string $htmlType): string {
+    $mapping = [
+      'checkbox' => 'Checkbox',
+      'radio' => 'Radio',
+      'select' => 'Select',
+      'textarea' => 'Textarea',
+      'text' => 'Text',
+    ];
+    return $mapping[$htmlType] ?? '';
   }
 
     public static function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -181,7 +181,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
 
     public static function getPriceFields(array $event): array {
       return \Civi\Api4\Event::get(FALSE)
-        ->addSelect('price_field.*')
+        ->addSelect('price_field.*', 'price_field_value.id')
         ->addJoin(
           'PriceSetEntity AS price_set_entity',
           'INNER',
@@ -198,6 +198,13 @@ abstract class CRM_Remoteevent_RegistrationProfile {
           'PriceField AS price_field',
           'LEFT',
           ['price_field.price_set_id', '=', 'price_set.id']
+        )
+        // For price fields with a selectable quantity, there is one single price field value; include its ID.
+        ->addJoin(
+          'PriceFieldValue AS price_field_value',
+          'LEFT',
+          ['price_field_value.price_field_id', '=', 'price_field.id'],
+          ['price_field.is_enter_qty', '=', TRUE]
         )
         ->addWhere('id', '=', $event['id'])
         ->execute()

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -248,96 +248,98 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return static::$priceFieldValues[$priceFieldId];
   }
 
-    /**
-     * @phpstan-param array<string, mixed> $event
-     *
-     * @phpstan-return array<string, array<string, mixed>>
-     * @throws \CRM_Core_Exception
-     */
-    public function getProfilePriceFields(array $event, ?string $locale = NULL): array
-    {
-        $fields = [];
+  /**
+   * @phpstan-param array<string, mixed> $event
+   *
+   * @phpstan-return array<string, array<string, mixed>>
+   * @throws \CRM_Core_Exception
+   */
+  public function getProfilePriceFields(array $event, ?string $locale = NULL): array {
+    $fields = [];
 
-        if (!(bool) $event['is_monetary']) {
-            return $fields;
-        }
-
-        $priceFields = self::getPriceFields($event);
-        if (count($priceFields) === 0) {
-           return $fields;
-        }
-
-        $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
-        $fields['price'] = [
-            'type' => 'fieldset',
-            'name' => 'price',
-            // TODO: Is the label correctly localised with the requested $locale?
-            'label' => $event['fee_label'],
-        ];
-        foreach ($priceFields as $priceField) {
-            $priceFieldValues = \Civi\Api4\PriceFieldValue::get(FALSE)
-                ->addSelect('id', 'label', 'amount')
-                ->addWhere('price_field_id', '=', $priceField['price_field.id'])
-                ->execute()
-                ->indexBy('id');
-            $field = [
-                // TODO: Validate types.
-                'type' => $priceField['price_field.html_type'],
-                'name' => 'price_' . $priceField['price_field.name'],
-                // TODO: Localize label with given $locale.
-                'label' => $priceField['price_field.label'],
-                'weight' => $priceField['price_field.weight'],
-                'required' => (bool) $priceField['price_field.is_required'],
-                'parent' => 'price',
-            ];
-            if ($priceField['price_field.is_enter_qty']) {
-                // Append price per unit.
-                $field['label'] .= sprintf(
-                  ' (%s)',
-                  CRM_Utils_Money::format(
-                    $priceFieldValues->first()['amount'],
-                    $event['currency']
-                  )
-                );
-            }
-            else {
-                $field['options'] = $priceFieldValues->column('label');
-            }
-
-            // Append price field value amounts in option labels.
-            if (isset($field['options']) && $priceField['price_field.is_display_amounts']) {
-                array_walk($field['options'], function(&$label, $id, $context) {
-                    $label .= sprintf(
-                        ' (%s)',
-                        CRM_Utils_Money::format(
-                          $context['priceFieldValues'][$id]['amount'],
-                          $context['event']['currency']
-                        )
-                    );
-                }, ['priceFieldValues' => $priceFieldValues, 'event' => $event]);
-            }
-
-            // Add prefixed help text.
-            if (isset($priceField['price_field.help_pre'])) {
-                // TODO: Localize with given $locale.
-                $field['prefix'] = $priceField['price_field.help_pre'];
-                $field['prefix_display'] = 'inline';
-            }
-
-            // Add suffixed help text.
-            if (isset($priceField['price_field.help_post'])) {
-                // TODO: Localize with given $locale.
-                $field['suffix'] = $priceField['price_field.help_post'];
-                $field['suffix_display'] = 'inline';
-            }
-
-            // TODO: Is the price field name unique across all price fields for
-            //       this event?
-            $fields['price_' . $priceField['price_field.name']] = $field;
-        }
-
-        return $fields;
+    if (!(bool) $event['is_monetary']) {
+      return $fields;
     }
+
+    $priceFields = self::getPriceFields($event);
+    if (count($priceFields) === 0) {
+      return $fields;
+    }
+
+    $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
+    $fields['price'] = [
+      'type' => 'fieldset',
+      'name' => 'price',
+      // TODO: Is the label correctly localised with the requested $locale?
+      'label' => $event['fee_label'],
+    ];
+    foreach ($priceFields as $priceField) {
+      $priceFieldValues = \Civi\Api4\PriceFieldValue::get(FALSE)
+        ->addSelect('id', 'label', 'amount')
+        ->addWhere('price_field_id', '=', $priceField['price_field.id'])
+        ->execute()
+        ->indexBy('id');
+      $field = [
+        // TODO: Validate types.
+        'type' => $priceField['price_field.html_type'],
+        'name' => 'price_' . $priceField['price_field.name'],
+        // TODO: Localize label with given $locale.
+        'label' => $priceField['price_field.label'],
+        'weight' => $priceField['price_field.weight'],
+        'required' => (bool) $priceField['price_field.is_required'],
+        'parent' => 'price',
+      ];
+      if ($priceField['price_field.is_enter_qty']) {
+        // Append price per unit.
+        $field['label'] .= sprintf(
+          ' (%s)',
+          CRM_Utils_Money::format(
+            $priceFieldValues->first()['amount'],
+            $event['currency']
+          )
+        );
+      }
+      else {
+        $field['options'] = $priceFieldValues->column('label');
+      }
+
+      // Append price field value amounts in option labels.
+      if (isset($field['options']) && $priceField['price_field.is_display_amounts']) {
+        array_walk(
+          $field['options'],
+          function(&$label, $id, $context) {
+            $label .= sprintf(
+              ' (%s)',
+              CRM_Utils_Money::format(
+                $context['priceFieldValues'][$id]['amount'],
+                $context['event']['currency']
+              )
+            );
+          },
+          ['priceFieldValues' => $priceFieldValues, 'event' => $event]
+        );
+      }
+
+      // Add prefixed help text.
+      if (isset($priceField['price_field.help_pre'])) {
+        // TODO: Localize with given $locale.
+        $field['prefix'] = $priceField['price_field.help_pre'];
+        $field['prefix_display'] = 'inline';
+      }
+
+      // Add suffixed help text.
+      if (isset($priceField['price_field.help_post'])) {
+        // TODO: Localize with given $locale.
+        $field['suffix'] = $priceField['price_field.help_post'];
+        $field['suffix_display'] = 'inline';
+      }
+
+      // TODO: Is the price field name unique across all price fields for this event?
+      $fields['price_' . $priceField['price_field.name']] = $field;
+    }
+
+    return $fields;
+  }
 
     public function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
     {
@@ -570,7 +572,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         $errors[$fieldName] = $l10n->ts('Quantity must be numeric');
       }
 
-      // Validate price field value being a valid options.
+      // Validate price field value being a valid option.
       if (
         !$priceField['price_field.is_enter_qty']
         && (

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -13,11 +13,14 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
+declare(strict_types = 1);
+
 use Civi\RemoteParticipant\Event\Util\PaymentMethodUtil;
-use CRM_Remoteevent_ExtensionUtil as E;
-use Civi\Api4\Participant;
 use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
-use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
+use CRM_Remoteevent_ExtensionUtil as E;
+
+use Civi\Api4\Participant;
+use Civi\RemoteEvent as RemoteEvent;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 use Civi\RemoteParticipant\Event\ValidateEvent;
@@ -25,17 +28,8 @@ use Civi\RemoteParticipant\Event\ValidateEvent;
 /**
  * Abstract base to all registration profile implementations
  */
-abstract class CRM_Remoteevent_RegistrationProfile
-{
-
-    /**
-     * Get the internal name of the profile represented.
-     *
-     * This name has to be identical to the corresponding OptionGroupValue
-     *
-     * @return string name
-     */
-    abstract public function getName();
+// phpcs:ignore Generic.NamingConventions.AbstractClassNamePrefix.Missing
+abstract class CRM_Remoteevent_RegistrationProfile {
 
   /**
    * Get the internal name of the profile represented.
@@ -110,83 +104,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
    * phpcs:enable
    */
   abstract public function getFields($locale = NULL);
-
-  public function getAdditionalParticipantsFields(array $event,
-    ?int $maxParticipants = NULL,
-    ?string $locale = NULL
-  ): array {
-    $fields = [];
-    if (!empty($event['is_multiple_registrations'])) {
-      $maxParticipants = min(
-      $maxParticipants ?? $event['max_additional_participants'],
-      $event['max_additional_participants']
-      );
-      $additional_participants_profile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
-        $event['event_remote_registration.remote_registration_additional_participants_profile']
-      );
-      $additional_fields = $additional_participants_profile->getFields($locale);
-      $fields['additional_participants'] = [
-        'type' => 'fieldset',
-        'name' => 'additional_participants',
-        'label' => E::ts('Additional Participants'),
-        'weight' => 1000,
-        'description' => E::ts(
-          'Register up to %1 additional participants',
-          [1 => $event['max_additional_participants']]
-        ),
-      ];
-      for ($i = 1; $i <= $maxParticipants; $i++) {
-        $fields['additional_' . $i] = [
-          'type' => 'fieldset',
-          'name' => 'additional_' . $i,
-          'parent' => 'additional_participants',
-          'label' => E::ts('Additional Participant %1', [1 => $i]),
-          'weight' => 10,
-          'description' => E::ts('Registration data for additional participant %1', [1 => $i]),
-        ];
-        foreach ($additional_fields as $additional_field_name => $additional_field) {
-          $additional_field['entity_field_name'] ??= $additional_field['name'];
-          $additional_field['name'] = 'additional_' . $i . '_' . $additional_field['name'];
-          $additional_field['parent'] = empty($additional_field['parent'])
-            ? 'additional_' . $i
-            : 'additional_' . $i . '_' . $additional_field['parent'];
-          $fields['additional_' . $i . '_' . $additional_field_name] = $additional_field;
-        }
-      }
-    }
-    return $fields;
-  }
-
-  /**
-   * Add the default values to the form data, so people using this profile
-   * don't have to enter everything themselves.
-   */
-  public function addDefaultValues(GetParticipantFormEventBase $resultsEvent) {
-    $contact_field_mapping = [];
-    $participant_field_mapping = [];
-    $participant_value_callbacks = [];
-
-    foreach ($this->getFields() as $field_key => $field_spec) {
-      if (in_array($field_spec['type'], ['Value', 'fieldset', 'File'], TRUE)) {
-        continue;
-      }
-
-      // @phpstan-ignore method.deprecated
-      $entity_names = (array) ($field_spec['entity_name'] ?? $this->getFieldEntities($field_key));
-      $entity_field_name = $field_spec['entity_field_name'] ?? $field_key;
-      if (in_array('Contact', $entity_names, TRUE)) {
-        $contact_field_mapping[$entity_field_name] = $field_key;
-      }
-      if (in_array('Participant', $entity_names, TRUE)) {
-        $participant_field_mapping[$entity_field_name] = $field_key;
-        if (isset($field_spec['prefill_value_callback'])) {
-          $participant_value_callbacks[$field_key] = $field_spec['prefill_value_callback'];
-        }
-      }
-    }
-
-    // @phpstan-ignore method.deprecated
-    $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
 
   /**
    * @phpstan-param array{
@@ -356,44 +273,97 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $mapping[$htmlType] ?? '';
   }
 
-    public static function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
-    {
-        $fields = [];
-        if (!empty($event['is_multiple_registrations'])) {
-            $maxParticipants = min(
-              $maxParticipants ?? $event['max_additional_participants'],
-              $event['max_additional_participants']
-            );
-            $additional_participants_profile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
-                $event['event_remote_registration.remote_registration_additional_participants_profile']
-            );
-            $additional_fields = $additional_participants_profile->getFields($locale);
-            $additional_fields += static::getProfilePriceFields($event, $locale);
-            $fields['additional_participants'] = [
-                'type' => 'fieldset',
-                'name' => 'additional_participants',
-                'label' => E::ts('Additional Participants'),
-                'weight' => 1000,
-                'description' => E::ts('Register up to %1 additional participants', [1 => $event['max_additional_participants']]),
-            ];
-            for ($i = 1; $i <= $maxParticipants; $i++) {
-                $fields['additional_' . $i] = [
-                    'type' => 'fieldset',
-                    'name' => 'additional_' . $i,
-                    'parent' => 'additional_participants',
-                    'label' => E::ts('Additional Participant %1', [1 => $i]),
-                    'weight' => 10,
-                    'description' => E::ts('Registration data for additional participant %1', [1 => $i]),
-                ];
-                foreach ($additional_fields as $additional_field_name => $additional_field) {
-                    $additional_field['entity_field_name'] ??= $additional_field['name'];
-                    $additional_field['name'] = 'additional_' . $i . '_' . $additional_field['name'];
-                    $additional_field['parent'] = empty($additional_field['parent']) ? 'additional_' . $i : 'additional_' . $i . '_' . $additional_field['parent'];
-                    $fields['additional_' . $i . '_' . $additional_field_name] = $additional_field;
-                }
-            }
+  public static function getAdditionalParticipantsFields(array $event,
+    ?int $maxParticipants = NULL,
+    ?string $locale = NULL
+  ): array {
+    $fields = [];
+    if (!empty($event['is_multiple_registrations'])) {
+      $maxParticipants = min(
+      $maxParticipants ?? $event['max_additional_participants'],
+      $event['max_additional_participants']
+      );
+      $additional_participants_profile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+        $event['event_remote_registration.remote_registration_additional_participants_profile']
+      );
+      $additional_fields = $additional_participants_profile->getFields($locale);
+            $additional_fields += self::getProfilePriceFields($event, $locale);
+      $fields['additional_participants'] = [
+        'type' => 'fieldset',
+        'name' => 'additional_participants',
+        'label' => E::ts('Additional Participants'),
+        'weight' => 1000,
+        'description' => E::ts(
+          'Register up to %1 additional participants',
+          [1 => $event['max_additional_participants']]
+        ),
+      ];
+      for ($i = 1; $i <= $maxParticipants; $i++) {
+        $fields['additional_' . $i] = [
+          'type' => 'fieldset',
+          'name' => 'additional_' . $i,
+          'parent' => 'additional_participants',
+          'label' => E::ts('Additional Participant %1', [1 => $i]),
+          'weight' => 10,
+          'description' => E::ts('Registration data for additional participant %1', [1 => $i]),
+        ];
+        foreach ($additional_fields as $additional_field_name => $additional_field) {
+          $additional_field['entity_field_name'] ??= $additional_field['name'];
+          $additional_field['name'] = 'additional_' . $i . '_' . $additional_field['name'];
+          $additional_field['parent'] = empty($additional_field['parent'])
+            ? 'additional_' . $i
+            : 'additional_' . $i . '_' . $additional_field['parent'];
+          $fields['additional_' . $i . '_' . $additional_field_name] = $additional_field;
         }
-        return $fields;
+      }
+    }
+    return $fields;
+  }
+
+  /**
+   * Add the default values to the form data, so people using this profile
+   * don't have to enter everything themselves.
+   */
+  public function addDefaultValues(GetParticipantFormEventBase $resultsEvent) {
+    $contact_field_mapping = [];
+    $participant_field_mapping = [];
+    $participant_value_callbacks = [];
+
+    foreach ($this->getFields() as $field_key => $field_spec) {
+      if (in_array($field_spec['type'], ['Value', 'fieldset', 'File'], TRUE)) {
+        continue;
+      }
+
+      // @phpstan-ignore method.deprecated
+      $entity_names = (array) ($field_spec['entity_name'] ?? $this->getFieldEntities($field_key));
+      $entity_field_name = $field_spec['entity_field_name'] ?? $field_key;
+      if (in_array('Contact', $entity_names, TRUE)) {
+        $contact_field_mapping[$entity_field_name] = $field_key;
+      }
+      if (in_array('Participant', $entity_names, TRUE)) {
+        $participant_field_mapping[$entity_field_name] = $field_key;
+        if (isset($field_spec['prefill_value_callback'])) {
+          $participant_value_callbacks[$field_key] = $field_spec['prefill_value_callback'];
+        }
+      }
+    }
+
+    // @phpstan-ignore method.deprecated
+    $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
+
+    if ([] !== $participant_field_mapping && $resultsEvent->getParticipantID() > 0) {
+      $participant = Participant::get(FALSE)
+        ->setSelect(array_keys($participant_field_mapping))
+        ->addWhere('id', '=', $resultsEvent->getParticipantID())
+        ->execute()
+        ->single();
+
+      ParticipantFormEventUtil::mapToPrefill(
+        $participant,
+        $participant_field_mapping,
+        $resultsEvent,
+        $participant_value_callbacks
+      );
     }
   }
 
@@ -403,53 +373,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
    *   more complex validation (e.g. over multiple fields)
    *   have to be performed by the profile implementations
    *
-   * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
-   *      event triggered by the RemoteParticipant.validate or submit API call
-   */
-  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
-  public function validateSubmission($validationEvent) {
-    $data = $validationEvent->getSubmission();
-    $event = $validationEvent->getEvent();
-    $additionalParticipantsCount = array_reduce(
-      preg_grep('#^additional_([0-9]+)(_|$)#', array_keys($data)),
-      function(int $carry, string $item) {
-        $currentCount = (int) preg_filter('#^additional_([0-9]+)(.*?)$#', '$1', $item);
-        return max($carry, $currentCount);
-      },
-        0
-    );
-    $l10n = $validationEvent->getLocalisation();
-
-    // Validate number of participants.
-    if (
-        !empty($event['max_participants'])
-        && ($excessParticipants =
-          CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
-          + 1 + $additionalParticipantsCount - $event['max_participants'])
-        > 0
-    ) {
-      if (
-        !empty($event['has_waitlist'])
-            && (
-                $additionalParticipantsCount === 0
-                || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
-            )
-      ) {
-        $validationEvent->addWarning(
-        $l10n->ts('Not enough vacancies for the number of requested participants.')
-        . ' '
-        . $l10n->ts('%1 participant(s) will be added to the waiting list.', [1 => $excessParticipants])
-        );
-      }
-      else {
-        $validationEvent->addValidationError(
-          '',
-          $l10n->ts('Not enough vacancies for the number of requested participants.')
-        );
-      }
-    }
-
-  /**
    * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
    *   Event triggered by the RemoteParticipant.validate or submit API call.
    */
@@ -500,14 +423,15 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $event = $validationEvent->getEvent();
     $l10n = $validationEvent->getLocalisation();
     $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
-    $fields = $this->getFields() + static::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
+    $fields = $this->getFields()
+      + self::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
 
     foreach ($fields as $field_name => $field_spec) {
       $value = $data[$field_name] ?? NULL;
       if (
         !empty($field_spec['required']) && ($value === NULL || $value === '')
         // Files are always optional on update.
-        && ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')
+        && ('File' !== $field_spec['type'] || 'update' !== $validationEvent->getContext())
       ) {
         $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
       }
@@ -650,224 +574,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $priceFieldsToValidate;
   }
 
-    /**
-     * This function will tell you which entity/entities the given field
-     *   will relate to. It would mostly be Contact or Participant (or both)
-     *
-     * @param string $field_key
-     *   the field key as used by this profile
-     *
-     * @return array
-     *   list of entities
-     *
-     * @deprecated Specify entity name in field spec instead.
-     */
-    public function getFieldEntities($field_key)
-    {
-        // for now, we assume everything is contact, unless it's custom,
-        //   in which case we don't know - or more precisely are too lazy to find out.
-        if (preg_match('/^custom_/', $field_key)
-            || preg_match('/^\w+[.]\w+$/', $field_key)) {
-            return ['Contact', 'Participant'];
-        } else {
-            return ['Contact'];
-        }
-    }
-
-    /**
-     * Give the profile a chance to manipulate the contact data before it's being sent off to
-     *   the contact creation/update
-     *
-     * @param array $contact_data
-     *   contact data
-     *
-     * @return void
-     */
-    protected function adjustContactData(&$contact_data)
-    {
-        // this is just a stub. for now.
-    }
-
-    /**
-     * Give the profile a chance to manipulate the contact data before it's being sent off to
-     * the contact creation/update
-     *
-     * This is a public interface method for adjusting contact data, as self::adjustContactData()
-     * has protected visibility.
-     *
-     * @param array $contact_data
-     *
-     * @return void
-     */
-    public function modifyContactData(array &$contact_data): void {
-        $this->adjustContactData($contact_data);
-    }
-
-    /*************************************************************
-     *                HELPER / INFRASTRUCTURE                   **
-     *************************************************************/
-
-    /**
-     * Add the profile data to the get_form results
-     *
-     * @param \Civi\RemoteEvent $remote_event
-     *      event triggered by the RemoteParticipant.get_form API call
-     *
-     * @return \CRM_Remoteevent_RegistrationProfile
-     *      the profile
-     */
-    public static function getProfile($remote_event)
-    {
-        $params = $remote_event->getQueryParameters();
-        $event  = $remote_event->getEvent();
-
-        // get profile
-        switch ($remote_event->getContext()) {
-            case 'create':
-                if (empty($params['profile'])) {
-                    // use default profile
-                    $params['profile'] = $event['default_profile'];
-                }
-                $allowed_profiles = explode(',', $event['enabled_profiles']);
-                break;
-
-            case 'update':
-                if (empty($params['profile'])) {
-                    // use default profile
-                    $params['profile'] = $event['default_update_profile'];
-                }
-                $allowed_profiles = explode(',', $event['enabled_update_profiles']);
-                break;
-
-            default:
-                $allowed_profiles = [];
-        }
-
-        if (!is_array($value) || !is_string($value['filename'] ?? NULL) || $value['filename'] === ''
-            // File systems usually allow up to 255 characters.
-            || strlen($value['filename']) > 255 || !is_string($value['content'] ?? NULL)
-          ) {
-          $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
-          continue;
-        }
-
-        // simply add the fields from the profile
-        return CRM_Remoteevent_RegistrationProfile::getRegistrationProfile($params['profile']);
-    }
-
-    /**
-     * Add the profile data to the get_form results
-     *
-     * @param GetParticipantFormEventBase $get_form_results
-     *      event triggered by the RemoteParticipant.get_form API call
-     *
-     * @return array|null
-     *      returns API error if there is an issue
-     */
-    public static function addProfileData($get_form_results)
-    {
-        // simply add the fields from the profile
-        $profile = self::getProfile($get_form_results);
-      /**
-       * @phpstan-var array{
-       *   id: int,
-       *   currency: string,
-       *   fee_label: string,
-       *   is_monetary: int,
-       * } $event
-       */
-        $event = $get_form_results->getEvent();
-
-        // add the fields
-        $locale = $get_form_results->getLocale();
-        $fields = $profile->getFields($locale);
-        if ('create' === $get_form_results->getContext()) {
-          $profilePriceFields = static::getProfilePriceFields($event, $locale);
-          $fields += $profilePriceFields;
-          $fields += static::getPaymentMethodsFields(
-            $event,
-            $locale,
-            max(array_column($profilePriceFields, 'weight') + [0]),
-            PriceFieldUtil::hasRequiredPriceFields($event)
-          );
-          $fields += static::getAdditionalParticipantsFields($event, NULL, $locale);
-        }
-        $get_form_results->addFields($fields);
-
-        // add default values
-        $profile->addDefaultValues($get_form_results);
-
-        // add profile "field"
-        $get_form_results->addFields([
-             'profile' => [
-                 'name' => 'profile',
-                 'type' => 'Value',
-                 'value' => $profile->getName(),
-                 'label' => $profile->getLabel(),
-             ]
-        ]);
-    }
-
-    /**
-     * Validate the profile fields
-     *
-     * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
-     *      event triggered by the RemoteParticipant.validate or submit API call
-     */
-    public static function validateProfileData($validationEvent)
-    {
-        // simply add the fields from the profile
-        $profile = self::getProfile($validationEvent);
-
-        // run the validation
-        $profile->validateSubmission($validationEvent);
-    }
-
-
-    /**
-     * Get a class instance of the given registration profile
-     *
-     * @param string $profile_name
-     *      name of the profile
-     *
-     * @return CRM_Remoteevent_RegistrationProfile
-     *      the profile instance
-     *
-     * @throws Exception
-     *      if no profile implementation for this name is available
-     */
-    public static function getRegistrationProfile($profile_name)
-    {
-        $profile_list = new RegistrationProfileListEvent();
-        // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
-        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $profile_list);
-
-        return $profile_list->getProfileInstance($profile_name);
-    }
-
-    /**
-     * Get a list of all currently available registration profiles
-     *
-     * @return array
-     *   profile name => profile label
-     */
-    public static function getAvailableRegistrationProfiles()
-    {
-        $remote_event_profiles = new RegistrationProfileListEvent();
-        // Collect Profiles via Symfony Event
-        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $remote_event_profiles);
-
-        $profiles = [];
-        foreach ($remote_event_profiles->getProfiles() as $profile) {
-            $profiles[$profile->getName()] = $profile->getLabel();
-        }
-        if (!$this->validateFieldLength($field_spec, $value)) {
-          $validationEvent->addValidationError($field_name, $l10n->ts('Value too long'));
-        }
-      }
-    }
-  }
-
   /**
    * This function will tell you which entity/entities the given field
    *   will relate to. It would mostly be Contact or Participant (or both)
@@ -886,8 +592,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     if (preg_match('/^custom_/', $field_key)
         || preg_match('/^\w+[.]\w+$/', $field_key)) {
       return ['Contact', 'Participant'];
-    }
-    else {
+    } else {
       return ['Contact'];
     }
   }
@@ -920,7 +625,11 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $this->adjustContactData($contact_data);
   }
 
-  /**
+  /*************************************************************
+   *                HELPER / INFRASTRUCTURE                   **
+   *************************************************************/
+
+    /**
    * Add the profile data to the get_form results
    *
    * @param \Civi\RemoteEvent $remote_event
@@ -973,18 +682,38 @@ abstract class CRM_Remoteevent_RegistrationProfile
    * Add the profile data to the get_form results
    *
    * @param \Civi\RemoteParticipant\Event\GetParticipantFormEventBase $get_form_results
-   *      event triggered by the RemoteParticipant.get_form API call
+   *   event triggered by the RemoteParticipant.get_form API call
+   *
+   * @return array|null
+   *   returns API error if there is an issue
    */
   public static function addProfileData($get_form_results) {
     // simply add the fields from the profile
     $profile = self::getProfile($get_form_results);
+
+    /**
+     * @phpstan-var array{
+     *   id: int,
+     *   currency: string,
+     *   fee_label: string,
+     *   is_monetary: int,
+     * } $event
+     */
     $event = $get_form_results->getEvent();
 
     // add the fields
     $locale = $get_form_results->getLocale();
     $fields = $profile->getFields($locale);
     if ('create' === $get_form_results->getContext()) {
-      $fields += $profile->getAdditionalParticipantsFields($event, NULL, $locale);
+      $profilePriceFields = self::getProfilePriceFields($event, $locale);
+      $fields += $profilePriceFields;
+      $fields += self::getPaymentMethodsFields(
+        $event,
+        $locale,
+        max(array_column($profilePriceFields, 'weight') + [0]),
+        PriceFieldUtil::hasRequiredPriceFields($event)
+      );
+      $fields += self::getAdditionalParticipantsFields($event, NULL, $locale);
     }
     $get_form_results->addFields($fields);
 
@@ -1091,8 +820,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
       $default_profile_name = $event['event_remote_registration.remote_registration_default_profile'];
       if (isset($profiles[$default_profile_name])) {
         $event['default_profile'] = $default_profile_name;
-      }
-      else {
+      } else {
         $event['default_profile'] = '';
       }
       unset($event['event_remote_registration.remote_registration_default_profile']);
@@ -1109,8 +837,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
       $default_profile_name = $event['event_remote_registration.remote_registration_default_update_profile'];
       if (isset($profiles[$default_profile_name])) {
         $event['default_update_profile'] = $default_profile_name;
-      }
-      else {
+      } else {
         $event['default_update_profile'] = '';
       }
       unset($event['event_remote_registration.remote_registration_default_update_profile']);
@@ -1122,8 +849,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
       $enabled_profile_names = array_intersect($enabled_profiles, array_keys($profiles));
       $event['enabled_update_profiles'] = implode(',', $enabled_profile_names);
       unset($event['event_remote_registration.remote_registration_update_profiles']);
-    }
-    else {
+    } else {
       $event['enabled_update_profiles'] = [];
     }
 
@@ -1149,7 +875,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
    * @param array $data
    *   input data
    *
-   * @param string $mode
+   * @param string mode
    *   'exception' (default) throws an exception if some of the data is invalid,
    *   'filter' will simply drop those
    *
@@ -1168,8 +894,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         $value = $data[$field_key];
         if ($this->validateFieldValue($field_spec, $value)) {
           $return_values[$field_key] = $value;
-        }
-        else {
+        } else {
           if ($mode == 'exception') {
             throw new Exception(
             E::ts(
@@ -1227,8 +952,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         try {
           CRM_Utils_Type::validate($value, $validation);
           return TRUE;
-        }
-        catch (Exception $ex) {
+        } catch (Exception $ex) {
           return FALSE;
         }
 
@@ -1237,8 +961,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         if (substr($validation, 0, 6) == 'regex:') {
           if (NULL !== $value && strlen($value) > 0) {
             return preg_match(substr($validation, 6), $value) > 0;
-          }
-          else {
+          } else {
             return TRUE;
           }
         }
@@ -1339,7 +1062,8 @@ abstract class CRM_Remoteevent_RegistrationProfile
    *
    * @deprecated Overwrite addDefaultValues() if necessary.
    */
-  public function addDefaultContactValues(GetParticipantFormEventBase $resultsEvent,
+  public function addDefaultContactValues(
+    GetParticipantFormEventBase $resultsEvent,
     $contact_fields,
     $attribute_mapping = []
   ) {
@@ -1385,8 +1109,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         ]);
         $contact_data += $legacy_contact_data;
         ParticipantFormEventUtil::mapToPrefill($contact_data, $attribute_mapping, $resultsEvent, $value_callbacks);
-      }
-      catch (CRM_Core_Exception $ex) {
+      } catch (CRM_Core_Exception $ex) {
         // @ignoreException
         // there is no (unique) primary email
       }

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -27,7 +27,7 @@ use Civi\RemoteParticipant\Event\ValidateEvent;
 abstract class CRM_Remoteevent_RegistrationProfile
 {
 
-  /**
+    /**
      * Get the internal name of the profile represented.
      *
      * This name has to be identical to the corresponding OptionGroupValue
@@ -211,7 +211,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $fields['price'] = [
       'type' => 'fieldset',
       'name' => 'price',
-      // TODO: Is the label correctly localised with the requested $locale?
+      // TODO: Is this configurable option localizable?
       'label' => $event['fee_label'],
     ];
     foreach ($priceFields as $priceField) {
@@ -224,7 +224,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         // TODO: Validate types.
         'type' => $priceField['price_field.html_type'],
         'name' => 'price_' . $priceField['price_field.name'],
-        // TODO: Localize label with given $locale.
+        // TODO: Make configurable price field labels localizable.
         'label' => $priceField['price_field.label'],
         'weight' => $priceField['price_field.weight'],
         'required' => (bool) $priceField['price_field.is_required'],
@@ -263,14 +263,14 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
       // Add prefixed help text.
       if (isset($priceField['price_field.help_pre'])) {
-        // TODO: Localize with given $locale.
+        // TODO: Make configurable price field labels localizable.
         $field['prefix'] = $priceField['price_field.help_pre'];
         $field['prefix_display'] = 'inline';
       }
 
       // Add suffixed help text.
       if (isset($priceField['price_field.help_post'])) {
-        // TODO: Localize with given $locale.
+        // TODO: Make configurable price field labels localizable.
         $field['suffix'] = $priceField['price_field.help_post'];
         $field['suffix_display'] = 'inline';
       }
@@ -294,7 +294,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
                 $event['event_remote_registration.remote_registration_additional_participants_profile']
             );
             $additional_fields = $additional_participants_profile->getFields($locale);
-            $additional_fields += CRM_Remoteevent_RegistrationProfile::getProfilePriceFields($event, $locale);
+            $additional_fields += static::getProfilePriceFields($event, $locale);
             $fields['additional_participants'] = [
                 'type' => 'fieldset',
                 'name' => 'additional_participants',
@@ -425,7 +425,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $event = $validationEvent->getEvent();
     $l10n = $validationEvent->getLocalisation();
     $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
-    $fields = $this->getFields() + self::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
+    $fields = $this->getFields() + static::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
 
     foreach ($fields as $field_name => $field_spec) {
       $value = $data[$field_name] ?? NULL;
@@ -545,7 +545,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $priceFieldsToValidate;
   }
 
-  /**
+    /**
      * This function will tell you which entity/entities the given field
      *   will relate to. It would mostly be Contact or Participant (or both)
      *
@@ -569,7 +569,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         }
     }
 
-  /**
+    /**
      * Give the profile a chance to manipulate the contact data before it's being sent off to
      *   the contact creation/update
      *
@@ -669,8 +669,8 @@ abstract class CRM_Remoteevent_RegistrationProfile
         $locale = $get_form_results->getLocale();
         $fields = $profile->getFields($locale);
         if ('create' === $get_form_results->getContext()) {
-          $fields += CRM_Remoteevent_RegistrationProfile::getProfilePriceFields($event, $locale);
-          $fields += CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event, NULL, $locale);
+          $fields += static::getProfilePriceFields($event, $locale);
+          $fields += static::getAdditionalParticipantsFields($event, NULL, $locale);
         }
         $get_form_results->addFields($fields);
 

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -179,19 +179,145 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     // @phpstan-ignore method.deprecated
     $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
 
-    if ([] !== $participant_field_mapping && $resultsEvent->getParticipantID() > 0) {
-      $participant = Participant::get(FALSE)
-        ->setSelect(array_keys($participant_field_mapping))
-        ->addWhere('id', '=', $resultsEvent->getParticipantID())
-        ->execute()
-        ->single();
+    /**
+     * @param array $event
+     * @param string|null $locale
+     *
+     * @return array<string,array<string,mixed>>
+     * @throws \CRM_Core_Exception
+     */
+    public function getPriceFields(array $event, ?string $locale = NULL): array
+    {
+        $fields = [];
 
-      ParticipantFormEventUtil::mapToPrefill(
-        $participant,
-        $participant_field_mapping,
-        $resultsEvent,
-        $participant_value_callbacks
-      );
+        if (!(bool) $event['is_monetary']) {
+            return $fields;
+        }
+
+        $priceFields = \Civi\Api4\Event::get(FALSE)
+            ->addSelect('price_field.*')
+            ->addJoin(
+                'PriceSetEntity AS price_set_entity',
+                'INNER',
+                ['price_set_entity.entity_table', '=', '"civicrm_event"'],
+                ['price_set_entity.entity_id', '=', 'id']
+            )
+            ->addJoin(
+                'PriceSet AS price_set',
+                'INNER',
+                ['price_set.id', '=', 'price_set_entity.price_set_id'],
+                ['price_set.is_active', '=', 1]
+            )
+            ->addJoin(
+                'PriceField AS price_field',
+                'LEFT',
+                ['price_field.price_set_id', '=', 'price_set.id']
+            )
+            ->addWhere('id', '=', $event['id'])
+            ->execute();
+
+        if (count($priceFields) === 0) {
+           return $fields;
+        }
+
+        $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
+        $fields['price'] = [
+            'type' => 'fieldset',
+            'name' => 'price',
+            // TODO: Is the label correctly localised with the requested $locale?
+            'label' => $event['fee_label'],
+        ];
+        foreach ($priceFields as $priceField) {
+            $priceFieldValues = \Civi\Api4\PriceFieldValue::get(FALSE)
+                ->addSelect('id', 'label', 'amount')
+                ->addWhere('price_field_id', '=', $priceField['price_field.id'])
+                ->execute()
+                ->indexBy('id');
+            $field = [
+                // TODO: Validate types.
+                'type' => $priceField['price_field.html_type'],
+                'name' => $priceField['price_field.name'],
+                // TODO: Localize label with given $locale.
+                'label' => $priceField['price_field.label'],
+                'weight' => $priceField['price_field.weight'],
+                'required' => (bool) $priceField['price_field.is_required'],
+                'parent' => 'price',
+                'options' => $priceFieldValues->column('label'),
+            ];
+
+            // Append price field value amounts in option labels.
+            if ($priceField['price_field.is_display_amounts']) {
+                array_walk($field['options'], function(&$label, $id, $context) {
+                    $label .= sprintf(
+                        ' (%s)',
+                        CRM_Utils_Money::format(
+                          $context['priceFieldValues'][$id]['amount'],
+                          $context['event']['currency']
+                        )
+                    );
+                }, ['priceFieldValues' => $priceFieldValues, 'event' => $event]);
+            }
+
+            // Add prefixed help text.
+            if (isset($priceField['price_field.help_pre'])) {
+                // TODO: Localize with given $locale.
+                $field['prefix'] = $priceField['price_field.help_pre'];
+                $field['prefix_display'] = 'inline';
+            }
+
+            // Add suffixed help text.
+            if (isset($priceField['price_field.help_post'])) {
+                // TODO: Localize with given $locale.
+                $field['suffix'] = $priceField['price_field.help_post'];
+                $field['suffix_display'] = 'inline';
+            }
+
+            // TODO: Ids the price field name unique across all price fields for
+            //       this event?
+            $fields['price_' . $priceField['price_field.name']] = $field;
+        }
+
+        return $fields;
+    }
+
+    public function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
+    {
+        $fields = [];
+        if (!empty($event['is_multiple_registrations'])) {
+            $maxParticipants = min(
+              $maxParticipants ?? $event['max_additional_participants'],
+              $event['max_additional_participants']
+            );
+            $additional_participants_profile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+                $event['event_remote_registration.remote_registration_additional_participants_profile']
+            );
+            $additional_fields = $additional_participants_profile->getFields($locale);
+            $additional_fields += $additional_participants_profile->getPriceFields($event, $locale);
+            $fields['additional_participants'] = [
+                'type' => 'fieldset',
+                'name' => 'additional_participants',
+                'label' => E::ts('Additional Participants'),
+                'weight' => 1000,
+                'description' => E::ts('Register up to %1 additional participants', [1 => $event['max_additional_participants']]),
+            ];
+            for ($i = 1; $i <= $maxParticipants; $i++) {
+                $fields['additional_' . $i] = [
+                    'type' => 'fieldset',
+                    'name' => 'additional_' . $i,
+                    'parent' => 'additional_participants',
+                    'label' => E::ts('Additional Participant %1', [1 => $i]),
+                    'weight' => 10,
+                    'description' => E::ts('Registration data for additional participant %1', [1 => $i]),
+                ];
+                foreach ($additional_fields as $additional_field_name => $additional_field) {
+                    $additional_field['entity_field_name'] ??= $additional_field['name'];
+                    $additional_field['name'] = 'additional_' . $i . '_' . $additional_field['name'];
+                    $additional_field['parent'] = empty($additional_field['parent']) ? 'additional_' . $i : 'additional_' . $i . '_' . $additional_field['parent'];
+                    $fields['additional_' . $i . '_' . $additional_field_name] = $additional_field;
+                }
+            }
+        }
+        return $fields;
     }
   }
 
@@ -250,16 +376,160 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     // Validate field values.
     $fields = $this->getFields()
           + $this->getAdditionalParticipantsFields($event, $additionalParticipantsCount);
-    foreach ($fields as $field_name => $field_spec) {
-      $value = $data[$field_name] ?? NULL;
-      if (!empty($field_spec['required']) && ($value === NULL || $value === '') &&
-      // Files are always optional on update.
-      ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')) {
-        $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
-      }
-      elseif ($field_spec['type'] === 'File') {
-        if ($value === NULL) {
-          continue;
+        foreach ($fields as $field_name => $field_spec) {
+            $value = $data[$field_name] ?? NULL;
+            if (!empty($field_spec['required']) && ($value === null || $value === '') &&
+              // Files are always optional on update.
+              ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')) {
+                $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
+            } else if ($field_spec['type'] === 'File') {
+                if ($value === NULL) {
+                  continue;
+                }
+
+                if (!is_array($value) || !is_string($value['filename'] ?? NULL) || $value['filename'] === ''
+                  // File systems usually allow up to 255 characters.
+                  || strlen($value['filename']) > 255 || !is_string($value['content'] ?? NULL)
+                ) {
+                    $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+                    continue;
+                }
+
+                $maxFilesize = (int) ($field_spec['max_filesize'] ?? 0);
+                if ($maxFilesize > 0) {
+                    // The file might need up to 38 % more space through Base64 encoding.
+                    if (strlen($value['content']) > ceil($maxFilesize * 1.38)) {
+                        $validationEvent->addValidationError($field_name, $l10n->ts('File too large'));
+                    }
+                }
+            } else {
+                if (!$this->validateFieldValue($field_spec, $value)) {
+                    $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+                }
+                if (!$this->validateFieldLength($field_spec, $value)) {
+                    $validationEvent->addValidationError($field_name, $l10n->ts('Value too long'));
+                }
+            }
+        }
+
+        // Validate price fields.
+        if ((bool) $event['is_monetary']) {
+            foreach ($this->validatePriceFields($event, $data) as $field_name => $error) {
+                $validationEvent->addValidationError($field_name, $error);
+            }
+        }
+    }
+
+  /**
+   * @param array $event
+   * @param array $submission
+   * @param \CRM_Remoteevent_Localisation $l10n
+   *
+   * @return array<string, string>
+   *   An array with field names as keys and corresponding localised error
+   *   messages as values.
+   * @throws \CRM_Core_Exception
+   */
+    protected function validatePriceFields(array $event, array $submission, CRM_Remoteevent_Localisation $l10n): array
+    {
+        $errors = [];
+        foreach ($this->getPriceFields($event) as $priceField) {
+            // TODO: Validate price field values.
+        }
+        return $errors;
+    }
+
+    /**
+     * This function will tell you which entity/entities the given field
+     *   will relate to. It would mostly be Contact or Participant (or both)
+     *
+     * @param string $field_key
+     *   the field key as used by this profile
+     *
+     * @return array
+     *   list of entities
+     *
+     * @deprecated Specify entity name in field spec instead.
+     */
+    public function getFieldEntities($field_key)
+    {
+        // for now, we assume everything is contact, unless it's custom,
+        //   in which case we don't know - or more precisely are too lazy to find out.
+        if (preg_match('/^custom_/', $field_key)
+            || preg_match('/^\w+[.]\w+$/', $field_key)) {
+            return ['Contact', 'Participant'];
+        } else {
+            return ['Contact'];
+        }
+    }
+
+    /**
+     * Give the profile a chance to manipulate the contact data before it's being sent off to
+     *   the contact creation/update
+     *
+     * @param array $contact_data
+     *   contact data
+     *
+     * @return void
+     */
+    protected function adjustContactData(&$contact_data)
+    {
+        // this is just a stub. for now.
+    }
+
+    /**
+     * Give the profile a chance to manipulate the contact data before it's being sent off to
+     * the contact creation/update
+     *
+     * This is a public interface method for adjusting contact data, as self::adjustContactData()
+     * has protected visibility.
+     *
+     * @param array $contact_data
+     *
+     * @return void
+     */
+    public function modifyContactData(array &$contact_data): void {
+        $this->adjustContactData($contact_data);
+    }
+
+    /*************************************************************
+     *                HELPER / INFRASTRUCTURE                   **
+     *************************************************************/
+
+    /**
+     * Add the profile data to the get_form results
+     *
+     * @param RemoteEvent $remote_event
+     *      event triggered by the RemoteParticipant.get_form API call
+     *
+     * @return \CRM_Remoteevent_RegistrationProfile
+     *      the profile
+     */
+    public static function getProfile($remote_event)
+    {
+        $params = $remote_event->getQueryParameters();
+        $event  = $remote_event->getEvent();
+
+        // get profile
+        switch ($remote_event->getContext()) {
+            case 'create':
+                if (empty($params['profile'])) {
+                    // use default profile
+                    $params['profile'] = $event['default_profile'];
+                }
+                $allowed_profiles = explode(',', $event['enabled_profiles']);
+                break;
+
+            case 'update':
+                if (empty($params['profile'])) {
+                    // use default profile
+                    $params['profile'] = $event['default_update_profile'];
+                }
+                $allowed_profiles = explode(',', $event['enabled_update_profiles']);
+                break;
+
+            default:
+                $allowed_profiles = [];
         }
 
         if (!is_array($value) || !is_string($value['filename'] ?? NULL) || $value['filename'] === ''
@@ -270,12 +540,31 @@ abstract class CRM_Remoteevent_RegistrationProfile {
           continue;
         }
 
-        $maxFilesize = (int) ($field_spec['max_filesize'] ?? 0);
-        if ($maxFilesize > 0) {
-          // The file might need up to 38 % more space through Base64 encoding.
-          if (strlen($value['content']) > ceil($maxFilesize * 1.38)) {
-            $validationEvent->addValidationError($field_name, $l10n->ts('File too large'));
-          }
+        // simply add the fields from the profile
+        return CRM_Remoteevent_RegistrationProfile::getRegistrationProfile($params['profile']);
+    }
+
+    /**
+     * Add the profile data to the get_form results
+     *
+     * @param GetParticipantFormEventBase $get_form_results
+     *      event triggered by the RemoteParticipant.get_form API call
+     *
+     * @return array|null
+     *      returns API error if there is an issue
+     */
+    public static function addProfileData($get_form_results)
+    {
+        // simply add the fields from the profile
+        $profile = self::getProfile($get_form_results);
+        $event = $get_form_results->getEvent();
+
+        // add the fields
+        $locale = $get_form_results->getLocale();
+        $fields = $profile->getFields($locale);
+        if ('create' === $get_form_results->getContext()) {
+          $fields += $profile->getPriceFields($event, $locale);
+          $fields += $profile->getAdditionalParticipantsFields($event, NULL, $locale);
         }
       }
       else {

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -13,6 +13,7 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
+use Civi\RemoteParticipant\Event\Util\PaymentMethodUtil;
 use CRM_Remoteevent_ExtensionUtil as E;
 use Civi\Api4\Participant;
 use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
@@ -294,22 +295,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
   /**
    * @phpstan-param array{
-   *   id: int,
-   *   currency: string,
-   *   fee_label: string,
-   *   is_monetary: int,
-   * } $event
-   */
-  public static function hasRequiredPriceFields(array $event): bool {
-    return in_array(
-      TRUE,
-      array_column(PriceFieldUtil::getPriceFields($event), 'price_field.is_required'),
-      FALSE
-    );
-  }
-
-  /**
-   * @phpstan-param array{
    *    id: int,
    *    currency: string,
    *    fee_label: string,
@@ -338,7 +323,6 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
     $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
 
-    // TODO: Get supported payment methods from remote event configuration.
     $fields['payment'] = [
       'type' => 'fieldset',
       'name' => 'payment',
@@ -350,85 +334,14 @@ abstract class CRM_Remoteevent_RegistrationProfile
       'type' => 'Select',
       'name' => 'payment_method',
       'label' => $l10n->ts('Payment Method'),
-      'options' => [],
+      'options' => PaymentMethodUtil::getPaymentMethodOptions($event, $locale),
       'required' => $paymentRequired,
       'parent' => 'payment',
       'weight' => 0,
     ];
-
-    if ((bool) $event['is_pay_later']) {
-      $fields['payment_method']['options']['pay_later'] = $event['pay_later_text'] ?? $l10n->ts('Pay Later');
-      // TODO: Add notes from $event['pay_later_receipt'].
+    foreach (array_keys($fields['payment_method']['options']) as $paymentMethod) {
+      $fields += PaymentMethodUtil::getPaymentMethodFields($event, $paymentMethod, $locale);
     }
-
-    // TODO: Allow more custom payment methods that require sending back data
-    //       (instead of processing the payment on the remote environment).
-    $fields['payment_method']['options']['sepa'] = $l10n->ts('SEPA Direct Debit');
-    $fields['payment_method_sepa_account_holder'] = [
-      'type' => 'Text',
-      'name' => 'payment_method_sepa_account_holder',
-      'label' => $l10n->ts('Account Holder'),
-      'required' => FALSE,
-      'maxlength' => 34,
-      'parent' => 'payment_method',
-      'weight' => 1,
-      'dependencies' => [
-        [
-          'command' => 'hide',
-          'dependee_field' => 'payment_method',
-          'dependee_value' => 'sepa',
-        ],
-      ],
-    ];
-    $fields['payment_method_sepa_iban'] = [
-      'type' => 'Text',
-      'name' => 'payment_method_sepa_iban',
-      'label' => $l10n->ts('IBAN'),
-      'required' => TRUE,
-      'maxlength' => 34,
-      'parent' => 'payment_method',
-      'weight' => 1,
-      'dependencies' => [
-        [
-          'command' => 'hide',
-          'dependee_field' => 'payment_method',
-          'dependee_value' => 'sepa',
-        ],
-      ],
-    ];
-    $fields['payment_method_sepa_bic'] = [
-      'type' => 'Text',
-      'name' => 'payment_method_sepa_bic',
-      'label' => $l10n->ts('BIC'),
-      'required' => TRUE,
-      'maxlength' => 11,
-      'parent' => 'payment_method',
-      'weight' => 1,
-      'dependencies' => [
-        [
-          'command' => 'hide',
-          'dependee_field' => 'payment_method',
-          'dependee_value' => 'sepa',
-        ],
-      ],
-    ];
-    $fields['payment_method_sepa_bank_name'] = [
-      'type' => 'Text',
-      'name' => 'payment_method_sepa_bank_name',
-      'label' => $l10n->ts('Bank Name'),
-      'required' => FALSE,
-      'maxlength' => 64,
-      'parent' => 'payment_method',
-      'weight' => 1,
-      'dependencies' => [
-        [
-          'command' => 'hide',
-          'dependee_field' => 'payment_method',
-          'dependee_value' => 'sepa',
-        ],
-      ],
-    ];
-
     return $fields;
   }
 
@@ -875,7 +788,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
             $event,
             $locale,
             max(array_column($profilePriceFields, 'weight') + [0]),
-            static::hasRequiredPriceFields($event)
+            PriceFieldUtil::hasRequiredPriceFields($event)
           );
           $fields += static::getAdditionalParticipantsFields($event, NULL, $locale);
         }

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -19,6 +19,7 @@ use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
 use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
+use Civi\RemoteParticipant\Event\ValidateEvent;
 
 /**
  * Abstract base to all registration profile implementations
@@ -374,111 +375,98 @@ abstract class CRM_Remoteevent_RegistrationProfile
       }
     }
 
-    /**
-     * Validate the profile fields individually.
-     * This only validates the mere data types,
-     *   more complex validation (e.g. over multiple fields)
-     *   have to be performed by the profile implementations
-     *
-     * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
-     *      event triggered by the RemoteParticipant.validate or submit API call
-     */
-    public function validateSubmission($validationEvent)
-    {
-        $data = $validationEvent->getSubmission();
-        $event = $validationEvent->getEvent();
-        $additionalParticipantsCount = array_reduce(
-          preg_grep('#^additional_([0-9]+)(_|$)#', array_keys($data)),
-          function(int $carry, string $item) {
-            $currentCount = (int) preg_filter('#^additional_([0-9]+)(.*?)$#', '$1', $item);
-            return max($carry, $currentCount);
-          },
-          0
+  /**
+   * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
+   *   Event triggered by the RemoteParticipant.validate or submit API call.
+   */
+  public function validateSubmission(ValidateEvent $validationEvent) {
+    $this->validateNumberOfParticipants($validationEvent);
+    $this->validateFieldValues($validationEvent);
+    $this->validatePriceFields($validationEvent);
+  }
+
+  protected function validateNumberOfParticipants(ValidateEvent $validationEvent): void {
+    $event = $validationEvent->getEvent();
+    $l10n = $validationEvent->getLocalisation();
+    $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
+
+    if (
+      !empty($event['max_participants'])
+      && ($excessParticipants =
+        CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
+        + $validationEvent->getRequestedParticipantCount($additionalParticipantsCount)
+        - $event['max_participants'])
+      > 0
+    ) {
+      if (
+        !empty($event['has_waitlist'])
+        && (
+          $additionalParticipantsCount === 0
+          || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+        )
+      ) {
+        $validationEvent->addWarning(
+          $l10n->ts('Not enough vacancies for the number of requested participants.')
+          . ' '
+          . $l10n->ts('%1 participant(s) will be added to the waiting list.', [1 => $excessParticipants])
         );
-        $l10n = $validationEvent->getLocalisation();
-
-        // Validate number of participants.
-        if (
-            !empty($event['max_participants'])
-            && ($excessParticipants =
-              CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
-              + $validationEvent->getRequestedParticipantCount($additionalParticipantsCount)
-              - $event['max_participants'])
-            > 0
-        ) {
-            if (
-                !empty($event['has_waitlist'])
-                    && (
-                        $additionalParticipantsCount === 0
-                        || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
-                    )
-            ) {
-                $validationEvent->addWarning(
-                    $l10n->ts('Not enough vacancies for the number of requested participants.')
-                    . ' '
-                    . $l10n->ts('%1 participant(s) will be added to the waiting list.', [1 => $excessParticipants])
-                );
-            }
-            else {
-                $validationEvent->addValidationError('', $l10n->ts('Not enough vacancies for the number of requested participants.'));
-            }
-        }
-
-        // Validate field values.
-        $fields = $this->getFields()
-          + CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
-        foreach ($fields as $field_name => $field_spec) {
-            $value = $data[$field_name] ?? NULL;
-            if (
-              !empty($field_spec['required']) && ($value === null || $value === '')
-              // Files are always optional on update.
-              && ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')
-            ) {
-                $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
-            }
-            elseif ($field_spec['type'] === 'File') {
-                if ($value === NULL) {
-                  continue;
-                }
-
-                if (!is_array($value) || !is_string($value['filename'] ?? NULL) || $value['filename'] === ''
-                  // File systems usually allow up to 255 characters.
-                  || strlen($value['filename']) > 255 || !is_string($value['content'] ?? NULL)
-                ) {
-                    $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
-                    continue;
-                }
-
-                $maxFilesize = (int) ($field_spec['max_filesize'] ?? 0);
-                if ($maxFilesize > 0) {
-                    // The file might need up to 38 % more space through Base64 encoding.
-                    if (strlen($value['content']) > ceil($maxFilesize * 1.38)) {
-                        $validationEvent->addValidationError($field_name, $l10n->ts('File too large'));
-                    }
-                }
-            }
-            else {
-                if (!$this->validateFieldValue($field_spec, $value)) {
-                    $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
-                }
-                if (!$this->validateFieldLength($field_spec, $value)) {
-                    $validationEvent->addValidationError($field_name, $l10n->ts('Value too long'));
-                }
-            }
-        }
-
-        // Validate price fields.
-        if ((bool) $event['is_monetary']) {
-            foreach (self::validatePriceFields(
-              $event,
-              $data,
-              $additionalParticipantsCount,
-              $l10n
-            ) as $field_name => $error) {
-                $validationEvent->addValidationError($field_name, $error);
-            }
-        }
+      }
+      else {
+        $validationEvent->addValidationError(
+          '',
+          $l10n->ts('Not enough vacancies for the number of requested participants.')
+        );
+      }
     }
+  }
+
+  protected function validateFieldValues(ValidateEvent $validationEvent): void {
+    $data = $validationEvent->getSubmission();
+    $event = $validationEvent->getEvent();
+    $l10n = $validationEvent->getLocalisation();
+    $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
+    $fields = $this->getFields() + self::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
+
+    foreach ($fields as $field_name => $field_spec) {
+      $value = $data[$field_name] ?? NULL;
+      if (
+        !empty($field_spec['required']) && ($value === NULL || $value === '')
+        // Files are always optional on update.
+        && ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')
+      ) {
+        $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
+      }
+      elseif ($field_spec['type'] === 'File') {
+        if ($value === NULL) {
+          continue;
+        }
+
+        if (!is_array($value) || !is_string($value['filename'] ?? NULL) || $value['filename'] === ''
+          // File systems usually allow up to 255 characters.
+          || strlen($value['filename']) > 255 || !is_string($value['content'] ?? NULL)
+        ) {
+          $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+          continue;
+        }
+
+        $maxFilesize = (int) ($field_spec['max_filesize'] ?? 0);
+        if ($maxFilesize > 0) {
+          // The file might need up to 38 % more space through Base64 encoding.
+          if (strlen($value['content']) > ceil($maxFilesize * 1.38)) {
+            $validationEvent->addValidationError($field_name, $l10n->ts('File too large'));
+          }
+        }
+      }
+      else {
+        if (!$this->validateFieldValue($field_spec, $value)) {
+          $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+        }
+        if (!$this->validateFieldLength($field_spec, $value)) {
+          $validationEvent->addValidationError($field_name, $l10n->ts('Value too long'));
+        }
+      }
+    }
+  }
 
   /**
    * @phpstan-param array<string, mixed> $event
@@ -489,13 +477,14 @@ abstract class CRM_Remoteevent_RegistrationProfile
    *   messages as values.
    * @throws \CRM_Core_Exception
    */
-  public static function validatePriceFields(
-    array $event,
-    array $submission,
-    int $additionalParticipantsCount,
-    CRM_Remoteevent_Localisation $l10n
-  ): array {
-    $errors = [];
+  protected function validatePriceFields(ValidateEvent $validationEvent): void {
+    $event = $validationEvent->getEvent();
+    if (!(bool) $event['is_monetary']) {
+      return;
+    }
+    $submission = $validationEvent->getSubmission();
+    $l10n = $validationEvent->getLocalisation();
+    $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
     $priceFields = PriceFieldUtil::getPriceFields($event);
     foreach (self::getPriceFieldsToValidate(
       $priceFields,
@@ -509,7 +498,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
       // Validate quantity being numeric.
       if ($priceField['price_field.is_enter_qty'] && !is_numeric($submission[$fieldName])) {
-        $errors[$fieldName] = $l10n->ts('Quantity must be numeric');
+        $validationEvent->addValidationError($fieldName, $l10n->ts('Quantity must be numeric'));
       }
 
       // Validate price field value being a valid option.
@@ -520,7 +509,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
           || !array_key_exists((int) $submission[$fieldName], $priceFieldValues)
         )
       ) {
-        $errors[$fieldName] = $l10n->ts('Invalid value');
+        $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
       }
 
       // Validate availability of price options.
@@ -531,12 +520,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
           : 1;
         $currentCount = \CRM_Event_BAO_Participant::priceSetOptionsCount($event['id'])[$priceFieldValueId] ?? 0;
         if ($currentCount + $requestedCount[$priceFieldValueId] > $priceFieldValues[$priceFieldValueId]['max_value']) {
-          $errors[$fieldName] = $l10n->ts('Maximum number of price option exceeded');
+          $validationEvent->addValidationError($fieldName, $l10n->ts('Maximum number of price option exceeded'));
         }
       }
     }
-
-    return $errors;
   }
 
   /**

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -25,8 +25,21 @@ use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 /**
  * Abstract base to all registration profile implementations
  */
-// phpcs:ignore Generic.NamingConventions.AbstractClassNamePrefix.Missing
-abstract class CRM_Remoteevent_RegistrationProfile {
+abstract class CRM_Remoteevent_RegistrationProfile
+{
+  /**
+   * @phpstan-var array<int, array<string, mixed>>
+   */
+  public static array $priceFieldValues = [];
+
+    /**
+     * Get the internal name of the profile represented.
+     *
+     * This name has to be identical to the corresponding OptionGroupValue
+     *
+     * @return string name
+     */
+    abstract public function getName();
 
   /**
    * Get the internal name of the profile represented.
@@ -179,37 +192,61 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     // @phpstan-ignore method.deprecated
     $this->addDefaultContactValues($resultsEvent, array_keys($contact_field_mapping), $contact_field_mapping);
 
-    public static function getPriceFields(array $event): array {
-      return \Civi\Api4\Event::get(FALSE)
-        ->addSelect('price_field.*', 'price_field_value.id')
-        ->addJoin(
-          'PriceSetEntity AS price_set_entity',
-          'INNER',
-          ['price_set_entity.entity_table', '=', '"civicrm_event"'],
-          ['price_set_entity.entity_id', '=', 'id']
-        )
-        ->addJoin(
-          'PriceSet AS price_set',
-          'INNER',
-          ['price_set.id', '=', 'price_set_entity.price_set_id'],
-          ['price_set.is_active', '=', 1]
-        )
-        ->addJoin(
-          'PriceField AS price_field',
-          'LEFT',
-          ['price_field.price_set_id', '=', 'price_set.id']
-        )
-        // For price fields with a selectable quantity, there is one single price field value; include its ID.
-        ->addJoin(
-          'PriceFieldValue AS price_field_value',
-          'LEFT',
-          ['price_field_value.price_field_id', '=', 'price_field.id'],
-          ['price_field.is_enter_qty', '=', TRUE]
-        )
-        ->addWhere('id', '=', $event['id'])
+  /**
+   * @phpstan-param array<string, mixed> $event
+   *
+   * @phpstan-return array<int, array<string, mixed>>
+   */
+  public static function getPriceFields(array $event): array {
+    return \Civi\Api4\Event::get(FALSE)
+      ->addSelect(
+        'price_field.*',
+        'price_field_value.id',
+        'price_field_value.max_value',
+      )
+      ->addJoin(
+        'PriceSetEntity AS price_set_entity',
+        'INNER',
+        ['price_set_entity.entity_table', '=', '"civicrm_event"'],
+        ['price_set_entity.entity_id', '=', 'id']
+      )
+      ->addJoin(
+        'PriceSet AS price_set',
+        'INNER',
+        ['price_set.id', '=', 'price_set_entity.price_set_id'],
+        ['price_set.is_active', '=', 1]
+      )
+      ->addJoin(
+        'PriceField AS price_field',
+        'LEFT',
+        ['price_field.price_set_id', '=', 'price_set.id']
+      )
+      // For price fields with a selectable quantity, there is one single price field value; include its ID.
+      ->addJoin(
+        'PriceFieldValue AS price_field_value',
+        'LEFT',
+        ['price_field_value.price_field_id', '=', 'price_field.id'],
+        ['price_field.is_enter_qty', '=', TRUE]
+      )
+      ->addWhere('id', '=', $event['id'])
+      ->execute()
+      ->indexBy('price_field.id')
+      ->getArrayCopy();
+  }
+
+  /**
+   * @phpstan-return array<int, array<string, mixed>>
+   */
+  public static function getPriceFieldValues(int $priceFieldId): array {
+    if (!isset(static::$priceFieldValues[$priceFieldId])) {
+      static::$priceFieldValues[$priceFieldId] = \Civi\Api4\PriceFieldValue::get(FALSE)
+        ->addWhere('price_field_id', '=', $priceFieldId)
         ->execute()
+        ->indexBy('id')
         ->getArrayCopy();
     }
+    return static::$priceFieldValues[$priceFieldId];
+  }
 
     /**
      * @phpstan-param array<string, mixed> $event
@@ -400,11 +437,14 @@ abstract class CRM_Remoteevent_RegistrationProfile {
           + $this->getAdditionalParticipantsFields($event, $additionalParticipantsCount);
         foreach ($fields as $field_name => $field_spec) {
             $value = $data[$field_name] ?? NULL;
-            if (!empty($field_spec['required']) && ($value === null || $value === '') &&
+            if (
+              !empty($field_spec['required']) && ($value === null || $value === '')
               // Files are always optional on update.
-              ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')) {
+              && ($field_spec['type'] !== 'File' || $validationEvent->getContext() !== 'update')
+            ) {
                 $validationEvent->addValidationError($field_name, $l10n->ts('Required'));
-            } else if ($field_spec['type'] === 'File') {
+            }
+            elseif ($field_spec['type'] === 'File') {
                 if ($value === NULL) {
                   continue;
                 }
@@ -424,7 +464,8 @@ abstract class CRM_Remoteevent_RegistrationProfile {
                         $validationEvent->addValidationError($field_name, $l10n->ts('File too large'));
                     }
                 }
-            } else {
+            }
+            else {
                 if (!$this->validateFieldValue($field_spec, $value)) {
                     $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
                 }
@@ -436,7 +477,12 @@ abstract class CRM_Remoteevent_RegistrationProfile {
 
         // Validate price fields.
         if ((bool) $event['is_monetary']) {
-            foreach ($this->validatePriceFields($event, $data, $l10n) as $field_name => $error) {
+            foreach ($this->validatePriceFields(
+                $event,
+                $data,
+                $additionalParticipantsCount,
+                $l10n
+            ) as $field_name => $error) {
                 $validationEvent->addValidationError($field_name, $error);
             }
         }
@@ -451,28 +497,68 @@ abstract class CRM_Remoteevent_RegistrationProfile {
    *   messages as values.
    * @throws \CRM_Core_Exception
    */
-  protected function validatePriceFields(array $event, array $submission, CRM_Remoteevent_Localisation $l10n): array {
+  protected function validatePriceFields(
+    array $event,
+    array $submission,
+    int $additionalParticipantsCount,
+    CRM_Remoteevent_Localisation $l10n
+  ): array {
     $errors = [];
-    foreach ($this->getProfilePriceFields($event) as $fieldName => $priceField) {
-      // Validate price field values inside the "price" fieldset.
-      if ('price' === $priceField['parent']) {
-        // Validate price field value is a valid options.
-        if (
-          isset($priceField['options'])
-          && !array_key_exists($submission[$fieldName], $priceField['options'])
-        ) {
-          $errors[$fieldName] = $l10n->ts('Invalid value');
-        }
+    $priceFields = static::getPriceFields($event);
+    /** @var array<string, int> $priceFieldsToValidate Mapping of submission field name => price field ID. */
+    $priceFieldsToValidate = static::getPriceFieldsToValidate($priceFields, $additionalParticipantsCount);
+    foreach ($priceFieldsToValidate as $fieldName => $priceFieldId) {
+      $priceField = $priceFields[$priceFieldId];
+      $priceFieldValues = static::getPriceFieldValues($priceField['price_field.id']);
+      $priceFieldValueId = $priceField['price_field.is_enter_qty']
+        ? array_key_first($priceFieldValues)
+        : (int) $submission[$fieldName];
 
-        // Validate quantity being numeric.
-        elseif (!is_numeric($submission[$fieldName])) {
-          $errors[$fieldName] = $l10n->ts('Quantity must be numeric');
-        }
+      // Validate quantity being numeric.
+      if ($priceField['price_field.is_enter_qty'] && !is_numeric($submission[$fieldName])) {
+        $errors[$fieldName] = $l10n->ts('Quantity must be numeric');
+      }
 
-        // TODO: Validate availability of price options.
+      // Validate price field value being a valid options.
+      if (
+        !$priceField['price_field.is_enter_qty']
+        && (
+          !is_numeric($submission[$fieldName])
+          || !array_key_exists((int) $submission[$fieldName], $priceFieldValues)
+        )
+      ) {
+        $errors[$fieldName] = $l10n->ts('Invalid value');
+      }
+
+      // Validate availability of price options.
+      if (isset($priceFieldValues[$priceFieldValueId]['max_value'])) {
+        $requestedCount[$priceFieldValueId] ??= 0;
+        $requestedCount[$priceFieldValueId] += $priceField['price_field.is_enter_qty']
+          ? (int) $submission[$fieldName]
+          : 1;
+        $currentCount = \CRM_Event_BAO_Participant::priceSetOptionsCount($event['id'])[$priceFieldValueId] ?? 0;
+        if ($currentCount + $requestedCount[$priceFieldValueId] > $priceFieldValues[$priceFieldValueId]['max_value']) {
+          $errors[$fieldName] = $l10n->ts('Maximum number of price option exceeded');
+        }
       }
     }
+
     return $errors;
+  }
+
+  public static function getPriceFieldsToValidate(array $priceFields, int $additionalParticipantsCount): array {
+    $priceFieldsToValidate = [];
+    foreach ($priceFields as $priceField) {
+      $priceFieldsToValidate['price_' . $priceField['price_field.name']] = $priceField['price_field.id'];
+    }
+    // Add all price fields for additional participants.
+    for ($i = 1; $i <= $additionalParticipantsCount; $i++) {
+      $priceFieldsToValidate += array_combine(
+        array_map(fn($fieldName) => 'additional_' . $i . '_' . $fieldName, array_keys($priceFieldsToValidate)),
+        $priceFieldsToValidate
+      );
+    }
+    return $priceFieldsToValidate;
   }
 
     /**

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -659,13 +659,18 @@ abstract class CRM_Remoteevent_RegistrationProfile
         : (int) $submission[$fieldName];
 
       // Validate quantity being numeric.
-      if ($priceField['price_field.is_enter_qty'] && !is_numeric($submission[$fieldName])) {
+      if (
+        $priceField['price_field.is_enter_qty']
+        && !empty($submission[$fieldName])
+        && !is_numeric($submission[$fieldName])
+      ) {
         $validationEvent->addValidationError($fieldName, $l10n->ts('Quantity must be numeric'));
       }
 
       // Validate price field value being a valid option.
       if (
         !$priceField['price_field.is_enter_qty']
+        && !empty($submission[$fieldName])
         && (
           !is_numeric($submission[$fieldName])
           || !array_key_exists((int) $submission[$fieldName], $priceFieldValues)

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -24,6 +24,7 @@ use Civi\RemoteEvent as RemoteEvent;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 use Civi\RemoteParticipant\Event\ValidateEvent;
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
 
 /**
  * Abstract base to all registration profile implementations
@@ -468,19 +469,15 @@ abstract class CRM_Remoteevent_RegistrationProfile {
   }
 
   /**
-   * @phpstan-param array<string, mixed> $event
-   * @phpstan-param array<string, mixed> $submission
-   *
-   * @phpstan-return array<string, string>
-   *   An array with field names as keys and corresponding localised error
-   *   messages as values.
    * @throws \CRM_Core_Exception
    */
   protected function validatePriceFields(ValidateEvent $validationEvent): void {
+    /** @phpstan-var array<string, mixed> $event*/
     $event = $validationEvent->getEvent();
     if (!(bool) $event['is_monetary']) {
       return;
     }
+    /* @phpstan-var array<string, mixed> $submission*/
     $submission = $validationEvent->getSubmission();
     $l10n = $validationEvent->getLocalisation();
     $additionalParticipantsCount = $validationEvent->getAdditionalParticipantsCount();
@@ -513,7 +510,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
           || !array_key_exists((int) $submission[$fieldName], $priceFieldValues)
         )
       ) {
-        $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+        $validationEvent->addValidationError($fieldName, $l10n->ts('Invalid value'));
       }
 
       // Validate availability of price options.

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -684,7 +684,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
    *   event triggered by the RemoteParticipant.get_form API call
    *
    */
-  public static function addProfileData($get_form_results) {
+  public static function addProfileData($get_form_results): void {
     // simply add the fields from the profile
     $profile = self::getProfile($get_form_results);
 

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -432,8 +432,58 @@ abstract class CRM_Remoteevent_RegistrationProfile
       }
     }
 
-    // Validate field values.
-    $fields = $this->getFields()
+    /**
+     * Validate the profile fields individually.
+     * This only validates the mere data types,
+     *   more complex validation (e.g. over multiple fields)
+     *   have to be performed by the profile implementations
+     *
+     * @param ValidateEvent $validationEvent
+     *      event triggered by the RemoteParticipant.validate or submit API call
+     */
+    public function validateSubmission($validationEvent)
+    {
+        $data = $validationEvent->getSubmission();
+        $event = $validationEvent->getEvent();
+        $additionalParticipantsCount = array_reduce(
+          preg_grep('#^additional_([0-9]+)(_|$)#', array_keys($data)),
+          function(int $carry, string $item) {
+            $currentCount = (int) preg_filter('#^additional_([0-9]+)(.*?)$#', '$1', $item);
+            return max($carry, $currentCount);
+          },
+          0
+        );
+        $l10n = $validationEvent->getLocalisation();
+
+        // Validate number of participants.
+        if (
+            !empty($event['max_participants'])
+            && ($excessParticipants =
+              CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
+              + static::getRequestedParticipantCount($event, $data, $additionalParticipantsCount)
+              - $event['max_participants'])
+            > 0
+        ) {
+            if (
+                !empty($event['has_waitlist'])
+                    && (
+                        $additionalParticipantsCount === 0
+                        || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+                    )
+            ) {
+                $validationEvent->addWarning(
+                    $l10n->ts('Not enough vacancies for the number of requested participants.')
+                    . ' '
+                    . $l10n->ts('%1 participant(s) will be added to the waiting list.', [1 => $excessParticipants])
+                );
+            }
+            else {
+                $validationEvent->addValidationError('', $l10n->ts('Not enough vacancies for the number of requested participants.'));
+            }
+        }
+
+        // Validate field values.
+        $fields = $this->getFields()
           + $this->getAdditionalParticipantsFields($event, $additionalParticipantsCount);
         foreach ($fields as $field_name => $field_spec) {
             $value = $data[$field_name] ?? NULL;
@@ -505,9 +555,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
   ): array {
     $errors = [];
     $priceFields = static::getPriceFields($event);
-    /** @var array<string, int> $priceFieldsToValidate Mapping of submission field name => price field ID. */
-    $priceFieldsToValidate = static::getPriceFieldsToValidate($priceFields, $additionalParticipantsCount);
-    foreach ($priceFieldsToValidate as $fieldName => $priceFieldId) {
+    foreach (static::getPriceFieldsToValidate(
+      $priceFields,
+      $additionalParticipantsCount
+    ) as $fieldName => $priceFieldId) {
       $priceField = $priceFields[$priceFieldId];
       $priceFieldValues = static::getPriceFieldValues($priceField['price_field.id']);
       $priceFieldValueId = $priceField['price_field.is_enter_qty']
@@ -546,6 +597,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $errors;
   }
 
+  /**
+   * @phpstan-return array<string, int>
+   *   Mapping of submission field name => price field ID
+   */
   public static function getPriceFieldsToValidate(array $priceFields, int $additionalParticipantsCount): array {
     $priceFieldsToValidate = [];
     foreach ($priceFields as $priceField) {
@@ -559,6 +614,45 @@ abstract class CRM_Remoteevent_RegistrationProfile
       );
     }
     return $priceFieldsToValidate;
+  }
+
+  public static function getRequestedParticipantCount(
+    array $event,
+    array $submission,
+    int $additionalParticipantsCount
+  ): int {
+    $priceFields = static::getPriceFields($event);
+    $maxRequestedParticipantCounts = [];
+    foreach (static::getPriceFieldsToValidate(
+      $priceFields,
+      $additionalParticipantsCount
+    ) as $fieldName => $priceFieldId) {
+      /** @var $participantNo 0 for the initial participant, 1-N for additional participants */
+      $participantNo = self::getAdditionalParticipantNo($fieldName) ?? 0;
+      $priceField = $priceFields[$priceFieldId];
+      $priceFieldValues = static::getPriceFieldValues($priceField['price_field.id']);
+      $priceFieldValueId = $priceField['price_field.is_enter_qty']
+        ? array_key_first($priceFieldValues)
+        : (int) $submission[$fieldName];
+
+      // For each participant (initial and additional), use the maximum count of participants in price fields to be used
+      // for this registration.
+      $maxRequestedParticipantCounts[$participantNo] = max(
+        $priceFieldValues[$priceFieldValueId]['count'] ?? 1,
+        $maxRequestedParticipantCounts[$participantNo]
+      );
+    }
+
+    return array_sum($maxRequestedParticipantCounts);
+  }
+
+  public static function getAdditionalParticipantNo(string $fieldKey): ?int {
+    $matches = [];
+    if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
+      return (int) $matches[1];
+    }
+
+    return NULL;
   }
 
     /**
@@ -585,7 +679,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         }
     }
 
-    /**
+  /**
      * Give the profile a chance to manipulate the contact data before it's being sent off to
      *   the contact creation/update
      *

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -192,7 +192,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
    *   id: int,
    *   currency: string,
    *   fee_label: string,
-   *   is_monetary: int
+   *   is_monetary: int,
    * } $event
    *
    * @param string|null $locale
@@ -221,11 +221,9 @@ abstract class CRM_Remoteevent_RegistrationProfile
     ];
 
     $maxWeight = 0;
-    $hasRequiredPriceFields = FALSE;
 
     foreach ($priceFields as $priceField) {
       $maxWeight = max($maxWeight, $priceField['price_field.weight']);
-      $hasRequiredPriceFields = $hasRequiredPriceFields || (bool) $priceField['price_field.is_required'];
 
       $priceFieldValues = \Civi\Api4\PriceFieldValue::get(FALSE)
         ->addSelect('id', 'label', 'amount')
@@ -291,79 +289,145 @@ abstract class CRM_Remoteevent_RegistrationProfile
       $fields['price_' . $priceField['price_field.name']] = $field;
     }
 
-    $fields += static::getPaymentProcessorFields($event, $locale, $maxWeight, $hasRequiredPriceFields);
-
     return $fields;
   }
 
-  public static function getPaymentProcessorFields(
+  /**
+   * @phpstan-param array{
+   *   id: int,
+   *   currency: string,
+   *   fee_label: string,
+   *   is_monetary: int,
+   * } $event
+   */
+  public static function hasRequiredPriceFields(array $event): bool {
+    return in_array(
+      TRUE,
+      array_column(PriceFieldUtil::getPriceFields($event), 'price_field.is_required'),
+      FALSE
+    );
+  }
+
+  /**
+   * @phpstan-param array{
+   *    id: int,
+   *    currency: string,
+   *    fee_label: string,
+   *    is_monetary: int,
+   *    payment_processor?: int|string|array,
+   *    is_pay_later: bool|int,
+   *    pay_later_text?: string,
+   *  } $event
+   *
+   * @param int $maxWeight
+   *   The maximum weight of price fields, so that the payment fieldset can be positioned as the last element.
+   *
+   * @phpstan-return array<string, array<string, mixed>>
+   */
+  public static function getPaymentMethodsFields(
     array $event,
     ?string $locale = NULL,
     int $maxWeight = 0,
     bool $paymentRequired = FALSE
   ): array {
     $fields = [];
+
+    if (!(bool) $event['is_monetary']) {
+      return $fields;
+    }
+
     $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
 
-    if (is_numeric($event['payment_processor']) || is_array($event['payment_processor'])) {
-      $fields['payment'] = [
-        'type' => 'fieldset',
-        'name' => 'payment',
-        'label' => $l10n->ts('Payment'),
-        'parent' => 'price',
-        'weight' => $maxWeight++,
-      ];
-      $fields['payment_processor'] = [
-        'type' => 'Select',
-        'name' => 'payment_processor',
-        'label' => $l10n->ts('Payment Method'),
-        'options' => [],
-        'required' => $paymentRequired,
-        'parent' => 'payment',
-        'weight' => 0,
-      ];
+    // TODO: Get supported payment methods from remote event configuration.
+    $fields['payment'] = [
+      'type' => 'fieldset',
+      'name' => 'payment',
+      'label' => $l10n->ts('Payment'),
+      'parent' => 'price',
+      'weight' => $maxWeight++,
+    ];
+    $fields['payment_method'] = [
+      'type' => 'Select',
+      'name' => 'payment_method',
+      'label' => $l10n->ts('Payment Method'),
+      'options' => [],
+      'required' => $paymentRequired,
+      'parent' => 'payment',
+      'weight' => 0,
+    ];
 
-      if ((bool) $event['is_pay_later']) {
-        $fields['payment_processor']['options'][0] = $event['pay_later_text'];
-        // TODO: Add notes from $event['pay_later_receipt'].
-      }
-
-      foreach ((array) $event['payment_processor'] as $paymentProcessorId) {
-        $paymentProcessor = \Civi\Api4\PaymentProcessor::get(FALSE)
-          ->addWhere('id', '=', $paymentProcessorId)
-          ->execute()
-          ->single();
-        $paymentProcessorObject = \Civi\Payment\System::singleton()->getByProcessor($paymentProcessor);
-
-        $fields['payment_processor']['options'][$paymentProcessorId] = $l10n->ts(
-          $paymentProcessorObject->getPaymentProcessor()['frontend_title']
-        );
-
-        $paymentProcessorFormFields = array_intersect_key(
-          $paymentProcessorObject->getPaymentFormFieldsMetadata(),
-          array_flip($paymentProcessorObject->getPaymentFormFields())
-        );
-        foreach ($paymentProcessorFormFields as $paymentProcessorField) {
-          $fieldName = 'payment_processor_' . $paymentProcessorId . '_' . $paymentProcessorField['name'];
-          $fields[$fieldName] = [
-            'type' => self::getQuickFormType($paymentProcessorField['htmlType']),
-            'name' => $fieldName,
-            'label' => $paymentProcessorField['title'],
-            'required' => (bool) $paymentProcessorField['is_required'],
-            'maxlength' => $paymentProcessorField['attributes']['maxlength'] ?? NULL,
-            'parent' => 'payment_processor',
-            'weight' => 1,
-            'dependencies' => [
-              [
-                'command' => 'hide',
-                'dependee_field' => 'payment_processor',
-                'dependee_value' => $paymentProcessorId,
-              ],
-            ],
-          ];
-        }
-      }
+    if ((bool) $event['is_pay_later']) {
+      $fields['payment_method']['options']['pay_later'] = $event['pay_later_text'] ?? $l10n->ts('Pay Later');
+      // TODO: Add notes from $event['pay_later_receipt'].
     }
+
+    // TODO: Allow more custom payment methods that require sending back data
+    //       (instead of processing the payment on the remote environment).
+    $fields['payment_method']['options']['sepa'] = $l10n->ts('SEPA Direct Debit');
+    $fields['payment_method_sepa_account_holder'] = [
+      'type' => 'Text',
+      'name' => 'payment_method_sepa_account_holder',
+      'label' => $l10n->ts('Account Holder'),
+      'required' => FALSE,
+      'maxlength' => 34,
+      'parent' => 'payment_method',
+      'weight' => 1,
+      'dependencies' => [
+        [
+          'command' => 'hide',
+          'dependee_field' => 'payment_method',
+          'dependee_value' => 'sepa',
+        ],
+      ],
+    ];
+    $fields['payment_method_sepa_iban'] = [
+      'type' => 'Text',
+      'name' => 'payment_method_sepa_iban',
+      'label' => $l10n->ts('IBAN'),
+      'required' => TRUE,
+      'maxlength' => 34,
+      'parent' => 'payment_method',
+      'weight' => 1,
+      'dependencies' => [
+        [
+          'command' => 'hide',
+          'dependee_field' => 'payment_method',
+          'dependee_value' => 'sepa',
+        ],
+      ],
+    ];
+    $fields['payment_method_sepa_bic'] = [
+      'type' => 'Text',
+      'name' => 'payment_method_sepa_bic',
+      'label' => $l10n->ts('BIC'),
+      'required' => TRUE,
+      'maxlength' => 11,
+      'parent' => 'payment_method',
+      'weight' => 1,
+      'dependencies' => [
+        [
+          'command' => 'hide',
+          'dependee_field' => 'payment_method',
+          'dependee_value' => 'sepa',
+        ],
+      ],
+    ];
+    $fields['payment_method_sepa_bank_name'] = [
+      'type' => 'Text',
+      'name' => 'payment_method_sepa_bank_name',
+      'label' => $l10n->ts('Bank Name'),
+      'required' => FALSE,
+      'maxlength' => 64,
+      'parent' => 'payment_method',
+      'weight' => 1,
+      'dependencies' => [
+        [
+          'command' => 'hide',
+          'dependee_field' => 'payment_method',
+          'dependee_value' => 'sepa',
+        ],
+      ],
+    ];
 
     return $fields;
   }
@@ -480,6 +544,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     $this->validateNumberOfParticipants($validationEvent);
     $this->validateFieldValues($validationEvent);
     $this->validatePriceFields($validationEvent);
+    $this->validatePaymentFields($validationEvent);
   }
 
   protected function validateNumberOfParticipants(ValidateEvent $validationEvent): void {
@@ -623,6 +688,31 @@ abstract class CRM_Remoteevent_RegistrationProfile
     }
   }
 
+  protected function validatePaymentFields(ValidateEvent $validationEvent): void {
+    $event = $validationEvent->getEvent();
+    if (!(bool) $event['is_monetary']) {
+      return;
+    }
+    $submission = $validationEvent->getSubmission();
+    $l10n = $validationEvent->getLocalisation();
+
+    switch ($submission['payment_method']) {
+      case 'pay_later':
+        break;
+
+      case 'sepa':
+        $error = CRM_Sepa_Logic_Verification::verifyIBAN($submission['payment_method_sepa_iban']);
+        if (NULL !== $error) {
+          $validationEvent->addValidationError('payment_method_sepa_iban', $l10n->ts('Invalid IBAN'));
+        }
+        $error = CRM_Sepa_Logic_Verification::verifyBIC($submission['payment_method_sepa_bic']);
+        if (NULL !== $error) {
+          $validationEvent->addValidationError('payment_method_sepa_bic', $l10n->ts('Invalid BIC'));
+        }
+        break;
+    }
+  }
+
   /**
    * @phpstan-return array<string, int>
    *   Mapping of submission field name => price field ID
@@ -760,13 +850,28 @@ abstract class CRM_Remoteevent_RegistrationProfile
     {
         // simply add the fields from the profile
         $profile = self::getProfile($get_form_results);
+      /**
+       * @phpstan-var array{
+       *   id: int,
+       *   currency: string,
+       *   fee_label: string,
+       *   is_monetary: int,
+       * } $event
+       */
         $event = $get_form_results->getEvent();
 
         // add the fields
         $locale = $get_form_results->getLocale();
         $fields = $profile->getFields($locale);
         if ('create' === $get_form_results->getContext()) {
-          $fields += static::getProfilePriceFields($event, $locale);
+          $profilePriceFields = static::getProfilePriceFields($event, $locale);
+          $fields += $profilePriceFields;
+          $fields += static::getPaymentMethodsFields(
+            $event,
+            $locale,
+            max(array_column($profilePriceFields, 'weight') + [0]),
+            static::hasRequiredPriceFields($event)
+          );
           $fields += static::getAdditionalParticipantsFields($event, NULL, $locale);
         }
         $get_form_results->addFields($fields);

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -13,12 +13,10 @@
 | written permission from the original author(s).        |
 +--------------------------------------------------------*/
 
-declare(strict_types = 1);
-
+use CRM_Remoteevent_ExtensionUtil as E;
 use Civi\Api4\Participant;
 use Civi\RemoteParticipant\Event\Util\ParticipantFormEventUtil;
-use CRM_Remoteevent_ExtensionUtil as E;
-
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
 use Civi\RemoteParticipant\Event\GetParticipantFormEventBase as GetParticipantFormEventBase;
 use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
 
@@ -27,12 +25,8 @@ use Civi\RemoteEvent\Event\RegistrationProfileListEvent;
  */
 abstract class CRM_Remoteevent_RegistrationProfile
 {
-  /**
-   * @phpstan-var array<int, array<string, mixed>>
-   */
-  public static array $priceFieldValues = [];
 
-    /**
+  /**
      * Get the internal name of the profile represented.
      *
      * This name has to be identical to the corresponding OptionGroupValue
@@ -195,73 +189,19 @@ abstract class CRM_Remoteevent_RegistrationProfile
   /**
    * @phpstan-param array<string, mixed> $event
    *
-   * @phpstan-return array<int, array<string, mixed>>
-   */
-  public static function getPriceFields(array $event): array {
-    return \Civi\Api4\Event::get(FALSE)
-      ->addSelect(
-        'price_field.*',
-        'price_field_value.id',
-        'price_field_value.max_value',
-      )
-      ->addJoin(
-        'PriceSetEntity AS price_set_entity',
-        'INNER',
-        ['price_set_entity.entity_table', '=', '"civicrm_event"'],
-        ['price_set_entity.entity_id', '=', 'id']
-      )
-      ->addJoin(
-        'PriceSet AS price_set',
-        'INNER',
-        ['price_set.id', '=', 'price_set_entity.price_set_id'],
-        ['price_set.is_active', '=', 1]
-      )
-      ->addJoin(
-        'PriceField AS price_field',
-        'LEFT',
-        ['price_field.price_set_id', '=', 'price_set.id']
-      )
-      // For price fields with a selectable quantity, there is one single price field value; include its ID.
-      ->addJoin(
-        'PriceFieldValue AS price_field_value',
-        'LEFT',
-        ['price_field_value.price_field_id', '=', 'price_field.id'],
-        ['price_field.is_enter_qty', '=', TRUE]
-      )
-      ->addWhere('id', '=', $event['id'])
-      ->execute()
-      ->indexBy('price_field.id')
-      ->getArrayCopy();
-  }
-
-  /**
-   * @phpstan-return array<int, array<string, mixed>>
-   */
-  public static function getPriceFieldValues(int $priceFieldId): array {
-    if (!isset(static::$priceFieldValues[$priceFieldId])) {
-      static::$priceFieldValues[$priceFieldId] = \Civi\Api4\PriceFieldValue::get(FALSE)
-        ->addWhere('price_field_id', '=', $priceFieldId)
-        ->execute()
-        ->indexBy('id')
-        ->getArrayCopy();
-    }
-    return static::$priceFieldValues[$priceFieldId];
-  }
-
-  /**
-   * @phpstan-param array<string, mixed> $event
+   * @param string|null $locale
    *
-   * @phpstan-return array<string, array<string, mixed>>
+   * @return array
    * @throws \CRM_Core_Exception
    */
-  public function getProfilePriceFields(array $event, ?string $locale = NULL): array {
+  public static function getProfilePriceFields(array $event, ?string $locale = NULL): array {
     $fields = [];
 
     if (!(bool) $event['is_monetary']) {
       return $fields;
     }
 
-    $priceFields = self::getPriceFields($event);
+    $priceFields = PriceFieldUtil::getPriceFields($event);
     if (count($priceFields) === 0) {
       return $fields;
     }
@@ -341,7 +281,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $fields;
   }
 
-    public function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
+    public static function getAdditionalParticipantsFields(array $event, ?int $maxParticipants = NULL, ?string $locale = NULL): array
     {
         $fields = [];
         if (!empty($event['is_multiple_registrations'])) {
@@ -353,7 +293,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
                 $event['event_remote_registration.remote_registration_additional_participants_profile']
             );
             $additional_fields = $additional_participants_profile->getFields($locale);
-            $additional_fields += $additional_participants_profile->getProfilePriceFields($event, $locale);
+            $additional_fields += CRM_Remoteevent_RegistrationProfile::getProfilePriceFields($event, $locale);
             $fields['additional_participants'] = [
                 'type' => 'fieldset',
                 'name' => 'additional_participants',
@@ -440,7 +380,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
      *   more complex validation (e.g. over multiple fields)
      *   have to be performed by the profile implementations
      *
-     * @param ValidateEvent $validationEvent
+     * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
      *      event triggered by the RemoteParticipant.validate or submit API call
      */
     public function validateSubmission($validationEvent)
@@ -462,7 +402,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
             !empty($event['max_participants'])
             && ($excessParticipants =
               CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
-              + static::getRequestedParticipantCount($event, $data, $additionalParticipantsCount)
+              + $validationEvent->getRequestedParticipantCount($additionalParticipantsCount)
               - $event['max_participants'])
             > 0
         ) {
@@ -486,7 +426,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
         // Validate field values.
         $fields = $this->getFields()
-          + $this->getAdditionalParticipantsFields($event, $additionalParticipantsCount);
+          + CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event, $additionalParticipantsCount);
         foreach ($fields as $field_name => $field_spec) {
             $value = $data[$field_name] ?? NULL;
             if (
@@ -529,11 +469,11 @@ abstract class CRM_Remoteevent_RegistrationProfile
 
         // Validate price fields.
         if ((bool) $event['is_monetary']) {
-            foreach ($this->validatePriceFields(
-                $event,
-                $data,
-                $additionalParticipantsCount,
-                $l10n
+            foreach (self::validatePriceFields(
+              $event,
+              $data,
+              $additionalParticipantsCount,
+              $l10n
             ) as $field_name => $error) {
                 $validationEvent->addValidationError($field_name, $error);
             }
@@ -549,20 +489,20 @@ abstract class CRM_Remoteevent_RegistrationProfile
    *   messages as values.
    * @throws \CRM_Core_Exception
    */
-  protected function validatePriceFields(
+  public static function validatePriceFields(
     array $event,
     array $submission,
     int $additionalParticipantsCount,
     CRM_Remoteevent_Localisation $l10n
   ): array {
     $errors = [];
-    $priceFields = static::getPriceFields($event);
-    foreach (static::getPriceFieldsToValidate(
+    $priceFields = PriceFieldUtil::getPriceFields($event);
+    foreach (self::getPriceFieldsToValidate(
       $priceFields,
       $additionalParticipantsCount
     ) as $fieldName => $priceFieldId) {
       $priceField = $priceFields[$priceFieldId];
-      $priceFieldValues = static::getPriceFieldValues($priceField['price_field.id']);
+      $priceFieldValues = PriceFieldUtil::getPriceFieldValues($priceField['price_field.id']);
       $priceFieldValueId = $priceField['price_field.is_enter_qty']
         ? array_key_first($priceFieldValues)
         : (int) $submission[$fieldName];
@@ -618,46 +558,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     return $priceFieldsToValidate;
   }
 
-  public static function getRequestedParticipantCount(
-    array $event,
-    array $submission,
-    int $additionalParticipantsCount
-  ): int {
-    $priceFields = static::getPriceFields($event);
-    $maxRequestedParticipantCounts = [];
-    foreach (static::getPriceFieldsToValidate(
-      $priceFields,
-      $additionalParticipantsCount
-    ) as $fieldName => $priceFieldId) {
-      /** @var $participantNo 0 for the initial participant, 1-N for additional participants */
-      $participantNo = self::getAdditionalParticipantNo($fieldName) ?? 0;
-      $priceField = $priceFields[$priceFieldId];
-      $priceFieldValues = static::getPriceFieldValues($priceField['price_field.id']);
-      $priceFieldValueId = $priceField['price_field.is_enter_qty']
-        ? array_key_first($priceFieldValues)
-        : (int) $submission[$fieldName];
-
-      // For each participant (initial and additional), use the maximum count of participants in price fields to be used
-      // for this registration.
-      $maxRequestedParticipantCounts[$participantNo] = max(
-        $priceFieldValues[$priceFieldValueId]['count'] ?? 1,
-        $maxRequestedParticipantCounts[$participantNo]
-      );
-    }
-
-    return array_sum($maxRequestedParticipantCounts);
-  }
-
-  public static function getAdditionalParticipantNo(string $fieldKey): ?int {
-    $matches = [];
-    if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
-      return (int) $matches[1];
-    }
-
-    return NULL;
-  }
-
-    /**
+  /**
      * This function will tell you which entity/entities the given field
      *   will relate to. It would mostly be Contact or Participant (or both)
      *
@@ -717,7 +618,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
     /**
      * Add the profile data to the get_form results
      *
-     * @param RemoteEvent $remote_event
+     * @param \Civi\RemoteEvent $remote_event
      *      event triggered by the RemoteParticipant.get_form API call
      *
      * @return \CRM_Remoteevent_RegistrationProfile
@@ -781,13 +682,77 @@ abstract class CRM_Remoteevent_RegistrationProfile
         $locale = $get_form_results->getLocale();
         $fields = $profile->getFields($locale);
         if ('create' === $get_form_results->getContext()) {
-          $fields += $profile->getProfilePriceFields($event, $locale);
-          $fields += $profile->getAdditionalParticipantsFields($event, NULL, $locale);
+          $fields += CRM_Remoteevent_RegistrationProfile::getProfilePriceFields($event, $locale);
+          $fields += CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event, NULL, $locale);
         }
-      }
-      else {
-        if (!$this->validateFieldValue($field_spec, $value)) {
-          $validationEvent->addValidationError($field_name, $l10n->ts('Invalid value'));
+        $get_form_results->addFields($fields);
+
+        // add default values
+        $profile->addDefaultValues($get_form_results);
+
+        // add profile "field"
+        $get_form_results->addFields([
+             'profile' => [
+                 'name' => 'profile',
+                 'type' => 'Value',
+                 'value' => $profile->getName(),
+                 'label' => $profile->getLabel(),
+             ]
+        ]);
+    }
+
+    /**
+     * Validate the profile fields
+     *
+     * @param \Civi\RemoteParticipant\Event\ValidateEvent $validationEvent
+     *      event triggered by the RemoteParticipant.validate or submit API call
+     */
+    public static function validateProfileData($validationEvent)
+    {
+        // simply add the fields from the profile
+        $profile = self::getProfile($validationEvent);
+
+        // run the validation
+        $profile->validateSubmission($validationEvent);
+    }
+
+
+    /**
+     * Get a class instance of the given registration profile
+     *
+     * @param string $profile_name
+     *      name of the profile
+     *
+     * @return CRM_Remoteevent_RegistrationProfile
+     *      the profile instance
+     *
+     * @throws Exception
+     *      if no profile implementation for this name is available
+     */
+    public static function getRegistrationProfile($profile_name)
+    {
+        $profile_list = new RegistrationProfileListEvent();
+        // dispatch Registration Profile Event and try to instantiate a profile class from $profile_name
+        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $profile_list);
+
+        return $profile_list->getProfileInstance($profile_name);
+    }
+
+    /**
+     * Get a list of all currently available registration profiles
+     *
+     * @return array
+     *   profile name => profile label
+     */
+    public static function getAvailableRegistrationProfiles()
+    {
+        $remote_event_profiles = new RegistrationProfileListEvent();
+        // Collect Profiles via Symfony Event
+        Civi::dispatcher()->dispatch(RegistrationProfileListEvent::NAME, $remote_event_profiles);
+
+        $profiles = [];
+        foreach ($remote_event_profiles->getProfiles() as $profile) {
+            $profiles[$profile->getName()] = $profile->getLabel();
         }
         if (!$this->validateFieldLength($field_spec, $value)) {
           $validationEvent->addValidationError($field_name, $l10n->ts('Value too long'));

--- a/Civi/RemoteEvent/Actions/SpawnEvent.php
+++ b/Civi/RemoteEvent/Actions/SpawnEvent.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Civi\RemoteEvent\Actions;
 
 use Civi\ActionProvider\Action\AbstractAction;
-use Civi\ActionProvider\Action\Contact\ContactActionUtils;
 use Civi\ActionProvider\ConfigContainer;
 use Civi\ActionProvider\Exception\ExecutionException;
 use Civi\ActionProvider\Parameter\ParameterBagInterface;

--- a/Civi/RemoteEvent/Actions/SpawnEvent.php
+++ b/Civi/RemoteEvent/Actions/SpawnEvent.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteEvent\Actions;
 
 use Civi\ActionProvider\Action\AbstractAction;
+use Civi\ActionProvider\Action\Contact\ContactActionUtils;
 use Civi\ActionProvider\ConfigContainer;
 use Civi\ActionProvider\Exception\ExecutionException;
 use Civi\ActionProvider\Parameter\ParameterBagInterface;
@@ -85,10 +86,12 @@ class SpawnEvent extends AbstractAction {
   /**
    * Run the action
    *
-   * @param $parameters
+   * @param \Civi\ActionProvider\Parameter\ParameterBagInterface $parameters
    *   The parameters to this action.
-   * @param $output
+   * @param \Civi\ActionProvider\Parameter\ParameterBagInterface $output
    *   The parameters this action can send back
+   *
+   * @todo remove dublicated 'template_id' parameterExists query
    */
   // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
   protected function doAction(ParameterBagInterface $parameters, ParameterBagInterface $output): void {
@@ -140,8 +143,8 @@ class SpawnEvent extends AbstractAction {
       $result = civicrm_api3('RemoteEvent', 'spawn', $apiParams);
       $output->setParameter('id', $result['id']);
     }
-    catch (\CRM_Core_Exception $e) {
-      throw new \RuntimeException(E::ts('Could not update or create an event.'), $e->getCode(), $e);
+    catch (\Exception $e) {
+      throw new ExecutionException(E::ts('Could not update or create an event.'), $e->getCode(), $e);
     }
   }
 

--- a/Civi/RemoteEvent/Actions/SpawnEvent.php
+++ b/Civi/RemoteEvent/Actions/SpawnEvent.php
@@ -85,9 +85,9 @@ class SpawnEvent extends AbstractAction {
   /**
    * Run the action
    *
-   * @param \Civi\ActionProvider\Parameter\ParameterBagInterface $parameters
+   * @param $parameters
    *   The parameters to this action.
-   * @param \Civi\ActionProvider\Parameter\ParameterBagInterface $output
+   * @param $output
    *   The parameters this action can send back
    */
   // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
@@ -140,8 +140,8 @@ class SpawnEvent extends AbstractAction {
       $result = civicrm_api3('RemoteEvent', 'spawn', $apiParams);
       $output->setParameter('id', $result['id']);
     }
-    catch (\Exception $e) {
-      throw new ExecutionException(E::ts('Could not update or create an event.'), $e->getCode(), $e);
+    catch (\CRM_Core_Exception $e) {
+      throw new \RuntimeException(E::ts('Could not update or create an event.'), $e->getCode(), $e);
     }
   }
 

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -17,8 +17,6 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteParticipant\Event;
 
-use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
-
 /**
  * Class ValidateEvent
  *
@@ -55,18 +53,24 @@ class RegistrationEvent extends ChangingEvent {
   protected array $additional_participants_data = [];
 
   /**
-   * @phpstan-var array<string, mixed>
+   * Check if the submission has errors
+   * @return bool
+   *   true if there is errors
    */
-    protected array $order_data = [];
+  public function hasErrors() {
+    return !empty($this->error_list);
+  }
 
-    /**
-     * Check if the submission has errors
-     * @return bool
-     *   true if there is errors
-     */
-    public function hasErrors()
-    {
-        return !empty($this->error_list);
+  /**
+   * {@inheritDoc}
+   */
+  public function getParticipantID(): ?int {
+    if (empty($this->participant['id'])) {
+      $participant_id = parent::getParticipantID();
+      if ($participant_id) {
+        $this->participant['id'] = $participant_id;
+      }
+      return $participant_id;
     }
     else {
       return (int) $this->participant['id'];
@@ -133,38 +137,22 @@ class RegistrationEvent extends ChangingEvent {
   }
 
   /**
-   * @phpstan-return array<string, mixed>
+   * @phpstan-param array<array<string, mixed>> $additional_participants_data
    */
-    public function getOrderData(): array {
-      return $this->order_data;
-    }
-
-    /**
-     * @phpstan-param array<array<string, mixed>> $additional_participants_data
-     */
-    public function setAdditionalParticipantsData(array $additional_participants_data): void
-    {
-        $this->additional_participants_data = $additional_participants_data;
-    }
+  public function setAdditionalParticipantsData(array $additional_participants_data): void {
+    $this->additional_participants_data = $additional_participants_data;
+  }
 
   /**
-   * @phpstan-param array<string, mixed> $order_data
+   * Set the contact_data object, which is used for
+   *   contact identification / creation
+   *
+   * @param array $contact_data
+   *    contact_data data
    */
-    public function setOrderData(array $order_data): void {
-      $this->order_data = $order_data;
-    }
-
-    /**
-     * Set the contact_data object, which is used for
-     *   contact identification / creation
-     *
-     * @param array $contact_data
-     *    contact_data data
-     */
-    public function setContactData($contact_data)
-    {
-        $this->contact_data = $contact_data;
-    }
+  public function setContactData($contact_data) {
+    $this->contact_data = $contact_data;
+  }
 
   /**
    * Get the contact_data object, which is used for
@@ -197,57 +185,6 @@ class RegistrationEvent extends ChangingEvent {
    */
   public function getSubmittedValue($value_name) {
     return $this->submission[$value_name] ?? NULL;
-  }
-
-  /**
-   * @phpstan-return array<string, mixed>
-   * @throws \CRM_Core_Exception
-   */
-  public function getPriceFieldValues(): array {
-    $values = [];
-
-    $event = $this->getEvent();
-    if (!(bool) $event['is_monetary']) {
-      return $values;
-    }
-
-    $priceFields = PriceFieldUtil::getPriceFields($event);
-
-    /**
-     * @var $participants
-     *   An array of participants to be registered, indexed by number of additional participant;
-     *   0 for the initial participant.
-     */
-    $participants = [
-      0 => ['id' => $this->getParticipantID()],
-    ] + $this->getAdditionalParticipantsData();
-
-    foreach ($participants as $participantNo => $participant) {
-      foreach ($priceFields as $priceField) {
-        $fieldName = ($participantNo > 0 ? "additional_{$participantNo}_" : '')
-          . "price_{$priceField['price_field.name']}";
-        $participantId = $participant['id'];
-        // The submitted value is either the selected price option (price field value ID) or the quantity of a specific
-        // price field value.
-        $value = $this->submission[$fieldName] ?? NULL;
-        if (is_numeric($value)) {
-          // phpcs:disable Drupal.Arrays.Array.ArrayIndentation
-          $values[] = [
-            'participant_id' => $participantId,
-            'price_field_id' => $priceField['price_field.id'],
-            'price_field_name' => $priceField['price_field.name'],
-            // If the price field has a single price field value, its ID is part of the price field metadata.
-            'price_field_value_id' => (bool) $priceField['price_field.is_enter_qty']
-              ? $priceField['price_field_value.id']
-              : $value,
-            'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
-          ];
-          // phpcs:enable
-        }
-      }
-    }
-
-    return $values;
   }
 
 }

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -17,6 +17,8 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteParticipant\Event;
 
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
+
 /**
  * Class ValidateEvent
  *
@@ -219,7 +221,7 @@ class RegistrationEvent extends ChangingEvent {
       return $values;
     }
 
-    $priceFields = \CRM_Remoteevent_RegistrationProfile::getPriceFields($event);
+    $priceFields = PriceFieldUtil::getPriceFields($event);
 
     /**
      * @var $participants

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -190,26 +190,6 @@ class RegistrationEvent extends ChangingEvent {
   }
 
   /**
-   * Get the event data
-   *
-   * @return array
-   *    event data
-   */
-  public function getEvent() {
-    return \CRM_Remoteevent_RemoteEvent::getRemoteEvent($this->getEventID());
-  }
-
-  /**
-   * Get the parameters of the original query
-   *
-   * @return array
-   *   parameters of the query
-   */
-  public function getQueryParameters() {
-    return $this->submission;
-  }
-
-  /**
    * @phpstan-return array<string, mixed>
    * @throws \CRM_Core_Exception
    */

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -55,24 +55,18 @@ class RegistrationEvent extends ChangingEvent {
   protected array $additional_participants_data = [];
 
   /**
-   * Check if the submission has errors
-   * @return bool
-   *   true if there is errors
+   * @phpstan-var array<string, mixed>
    */
-  public function hasErrors() {
-    return !empty($this->error_list);
-  }
+    protected array $order_data = [];
 
-  /**
-   * {@inheritDoc}
-   */
-  public function getParticipantID(): ?int {
-    if (empty($this->participant['id'])) {
-      $participant_id = parent::getParticipantID();
-      if ($participant_id) {
-        $this->participant['id'] = $participant_id;
-      }
-      return $participant_id;
+    /**
+     * Check if the submission has errors
+     * @return bool
+     *   true if there is errors
+     */
+    public function hasErrors()
+    {
+        return !empty($this->error_list);
     }
     else {
       return (int) $this->participant['id'];
@@ -139,22 +133,38 @@ class RegistrationEvent extends ChangingEvent {
   }
 
   /**
-   * @phpstan-param array<array<string, mixed>> $additional_participants_data
+   * @phpstan-return array<string, mixed>
    */
-  public function setAdditionalParticipantsData(array $additional_participants_data): void {
-    $this->additional_participants_data = $additional_participants_data;
-  }
+    public function getOrderData(): array {
+      return $this->order_data;
+    }
+
+    /**
+     * @phpstan-param array<array<string, mixed>> $additional_participants_data
+     */
+    public function setAdditionalParticipantsData(array $additional_participants_data): void
+    {
+        $this->additional_participants_data = $additional_participants_data;
+    }
 
   /**
-   * Set the contact_data object, which is used for
-   *   contact identification / creation
-   *
-   * @param array $contact_data
-   *    contact_data data
+   * @phpstan-param array<string, mixed> $order_data
    */
-  public function setContactData($contact_data) {
-    $this->contact_data = $contact_data;
-  }
+    public function setOrderData(array $order_data): void {
+      $this->order_data = $order_data;
+    }
+
+    /**
+     * Set the contact_data object, which is used for
+     *   contact identification / creation
+     *
+     * @param array $contact_data
+     *    contact_data data
+     */
+    public function setContactData($contact_data)
+    {
+        $this->contact_data = $contact_data;
+    }
 
   /**
    * Get the contact_data object, which is used for

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -187,48 +187,61 @@ class RegistrationEvent extends ChangingEvent {
     return $this->submission[$value_name] ?? NULL;
   }
 
-    /**
-     * Get the event data
-     *
-     * @return array
-     *    event data
-     */
-    public function getEvent()
-    {
-        return \CRM_Remoteevent_RemoteEvent::getRemoteEvent($this->getEventID());
-    }
-
-    /**
-     * Get the parameters of the original query
-     *
-     * @return array
-     *   parameters of the query
-     */
-    public function getQueryParameters()
-    {
-        return $this->submission;
-    }
+  /**
+   * Get the event data
+   *
+   * @return array
+   *    event data
+   */
+  public function getEvent() {
+    return \CRM_Remoteevent_RemoteEvent::getRemoteEvent($this->getEventID());
+  }
 
   /**
-   * @return array<string, mixed>
+   * Get the parameters of the original query
+   *
+   * @return array
+   *   parameters of the query
+   */
+  public function getQueryParameters() {
+    return $this->submission;
+  }
+
+  /**
+   * @phpstan-return array<string, mixed>
    * @throws \CRM_Core_Exception
    */
-    public function getPriceFieldValues(): array
-    {
-      $values = [];
+  public function getPriceFieldValues(): array {
+    $values = [];
 
-      $event = $this->getEvent();
-      if (!(bool) $event['is_monetary']) {
-        return $values;
-      }
+    $event = $this->getEvent();
+    if (!(bool) $event['is_monetary']) {
+      return $values;
+    }
 
-      foreach (\CRM_Remoteevent_RegistrationProfile::getPriceFields($event) as $priceField) {
+    $priceFields = \CRM_Remoteevent_RegistrationProfile::getPriceFields($event);
+
+    /**
+     * @var $participants
+     *   An array of participants to be registered, indexed by number of additional participant;
+     *   0 for the initial participant.
+     */
+    $participants = [
+      0 => ['id' => $this->getParticipantID()],
+    ] + $this->getAdditionalParticipantsData();
+
+    foreach ($participants as $participantNo => $participant) {
+      foreach ($priceFields as $priceField) {
+        $fieldName = ($participantNo > 0 ? "additional_{$participantNo}_" : '')
+          . "price_{$priceField['price_field.name']}";
+        $participantId = $participant['id'];
         // The submitted value is either the selected price option (price field value ID) or the quantity of a specific
         // price field value.
-        $value = $this->submission['price_' . $priceField['price_field.name']] ?? NULL;
+        $value = $this->submission[$fieldName] ?? NULL;
         if (is_numeric($value)) {
+          // phpcs:disable Drupal.Arrays.Array.ArrayIndentation
           $values[] = [
-            'participant_id' => $this->getParticipantID(),
+            'participant_id' => $participantId,
             'price_field_id' => $priceField['price_field.id'],
             'price_field_name' => $priceField['price_field.name'],
             // If the price field has a single price field value, its ID is part of the price field metadata.
@@ -237,24 +250,12 @@ class RegistrationEvent extends ChangingEvent {
               : $value,
             'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
           ];
+          // phpcs:enable
         }
       }
-
-      $additionalParticipantsPriceFields = \CRM_Remoteevent_RegistrationProfile::getPriceFields($event);
-      foreach ($this->getAdditionalParticipantsData() as $additionalParticipantNo => $additionalParticipant) {
-        foreach ($additionalParticipantsPriceFields as $priceField) {
-          $value = $this->submission['additional_' . $additionalParticipantNo . '_price_' . $priceField['price_field.name']] ?? NULL;
-          if (is_numeric($value)) {
-            $values[] = [
-              'participant_id' => $additionalParticipant['id'],
-              'price_field_name' => $priceField['price_field.name'],
-              'price_field_value_id' => (bool) $priceField['price_field.is_enter_qty'] ? $priceField['price_field_value.id'] : $value,
-              'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
-            ];
-          }
-        }
-      }
-
-      return $values;
     }
+
+    return $values;
+  }
+
 }

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -57,9 +57,9 @@ class RegistrationEvent extends ChangingEvent {
   /**
    * @phpstan-var array<string, mixed>
    */
-    protected array $order_data = [];
+  protected array $order_data = [];
 
-    /**
+  /**
    * Check if the submission has errors
    * @return bool
    *   true if there is errors
@@ -146,11 +146,11 @@ class RegistrationEvent extends ChangingEvent {
   /**
    * @phpstan-return array<string, mixed>
    */
-    public function getOrderData(): array {
-      return $this->order_data;
-    }
+  public function getOrderData(): array {
+    return $this->order_data;
+  }
 
-    /**
+  /**
    * @phpstan-param array<array<string, mixed>> $additional_participants_data
    */
   public function setAdditionalParticipantsData(array $additional_participants_data): void {
@@ -160,11 +160,11 @@ class RegistrationEvent extends ChangingEvent {
   /**
    * @phpstan-param array<string, mixed> $order_data
    */
-    public function setOrderData(array $order_data): void {
-      $this->order_data = $order_data;
-    }
+  public function setOrderData(array $order_data): void {
+    $this->order_data = $order_data;
+  }
 
-    /**
+  /**
    * Set the contact_data object, which is used for
    *   contact identification / creation
    *

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -17,6 +17,8 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteParticipant\Event;
 
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
+
 /**
  * Class ValidateEvent
  *
@@ -53,6 +55,11 @@ class RegistrationEvent extends ChangingEvent {
   protected array $additional_participants_data = [];
 
   /**
+   * @phpstan-var array<string, mixed>
+   */
+    protected array $order_data = [];
+
+    /**
    * Check if the submission has errors
    * @return bool
    *   true if there is errors
@@ -137,6 +144,13 @@ class RegistrationEvent extends ChangingEvent {
   }
 
   /**
+   * @phpstan-return array<string, mixed>
+   */
+    public function getOrderData(): array {
+      return $this->order_data;
+    }
+
+    /**
    * @phpstan-param array<array<string, mixed>> $additional_participants_data
    */
   public function setAdditionalParticipantsData(array $additional_participants_data): void {
@@ -144,6 +158,13 @@ class RegistrationEvent extends ChangingEvent {
   }
 
   /**
+   * @phpstan-param array<string, mixed> $order_data
+   */
+    public function setOrderData(array $order_data): void {
+      $this->order_data = $order_data;
+    }
+
+    /**
    * Set the contact_data object, which is used for
    *   contact identification / creation
    *
@@ -185,6 +206,57 @@ class RegistrationEvent extends ChangingEvent {
    */
   public function getSubmittedValue($value_name) {
     return $this->submission[$value_name] ?? NULL;
+  }
+
+  /**
+   * @phpstan-return array<string, mixed>
+   * @throws \CRM_Core_Exception
+   */
+  public function getPriceFieldValues(): array {
+    $values = [];
+
+    $event = $this->getEvent();
+    if (!(bool) $event['is_monetary']) {
+      return $values;
+    }
+
+    $priceFields = PriceFieldUtil::getPriceFields($event);
+
+    /**
+     * @var $participants
+     *   An array of participants to be registered, indexed by number of additional participant;
+     *   0 for the initial participant.
+     */
+    $participants = [
+      0 => ['id' => $this->getParticipantID()],
+    ] + $this->getAdditionalParticipantsData();
+
+    foreach ($participants as $participantNo => $participant) {
+      foreach ($priceFields as $priceField) {
+        $fieldName = ($participantNo > 0 ? "additional_{$participantNo}_" : '')
+          . "price_{$priceField['price_field.name']}";
+        $participantId = $participant['id'];
+        // The submitted value is either the selected price option (price field value ID) or the quantity of a specific
+        // price field value.
+        $value = $this->submission[$fieldName] ?? NULL;
+        if (is_numeric($value)) {
+          // phpcs:disable Drupal.Arrays.Array.ArrayIndentation
+          $values[] = [
+            'participant_id' => $participantId,
+            'price_field_id' => $priceField['price_field.id'],
+            'price_field_name' => $priceField['price_field.name'],
+            // If the price field has a single price field value, its ID is part of the price field metadata.
+            'price_field_value_id' => (bool) $priceField['price_field.is_enter_qty']
+              ? $priceField['price_field_value.id']
+              : $value,
+            'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
+          ];
+          // phpcs:enable
+        }
+      }
+    }
+
+    return $values;
   }
 
 }

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -223,12 +223,18 @@ class RegistrationEvent extends ChangingEvent {
       }
 
       foreach (\CRM_Remoteevent_RegistrationProfile::getPriceFields($event) as $priceField) {
+        // The submitted value is either the selected price option (price field value ID) or the quantity of a specific
+        // price field value.
         $value = $this->submission['price_' . $priceField['price_field.name']] ?? NULL;
         if (is_numeric($value)) {
           $values[] = [
             'participant_id' => $this->getParticipantID(),
+            'price_field_id' => $priceField['price_field.id'],
             'price_field_name' => $priceField['price_field.name'],
-            'price_field_value_id' => !(bool) $priceField['price_field.is_enter_qty'] ? $value : NULL,
+            // If the price field has a single price field value, its ID is part of the price field metadata.
+            'price_field_value_id' => (bool) $priceField['price_field.is_enter_qty']
+              ? $priceField['price_field_value.id']
+              : $value,
             'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
           ];
         }
@@ -242,7 +248,7 @@ class RegistrationEvent extends ChangingEvent {
             $values[] = [
               'participant_id' => $additionalParticipant['id'],
               'price_field_name' => $priceField['price_field.name'],
-              'price_field_value_id' => !(bool) $priceField['price_field.is_enter_qty'] ? $value : NULL,
+              'price_field_value_id' => (bool) $priceField['price_field.is_enter_qty'] ? $priceField['price_field_value.id'] : $value,
               'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
             ];
           }

--- a/Civi/RemoteParticipant/Event/RegistrationEvent.php
+++ b/Civi/RemoteParticipant/Event/RegistrationEvent.php
@@ -187,4 +187,68 @@ class RegistrationEvent extends ChangingEvent {
     return $this->submission[$value_name] ?? NULL;
   }
 
+    /**
+     * Get the event data
+     *
+     * @return array
+     *    event data
+     */
+    public function getEvent()
+    {
+        return \CRM_Remoteevent_RemoteEvent::getRemoteEvent($this->getEventID());
+    }
+
+    /**
+     * Get the parameters of the original query
+     *
+     * @return array
+     *   parameters of the query
+     */
+    public function getQueryParameters()
+    {
+        return $this->submission;
+    }
+
+  /**
+   * @return array<string, mixed>
+   * @throws \CRM_Core_Exception
+   */
+    public function getPriceFieldValues(): array
+    {
+      $values = [];
+
+      $event = $this->getEvent();
+      if (!(bool) $event['is_monetary']) {
+        return $values;
+      }
+
+      foreach (\CRM_Remoteevent_RegistrationProfile::getPriceFields($event) as $priceField) {
+        $value = $this->submission['price_' . $priceField['price_field.name']] ?? NULL;
+        if (is_numeric($value)) {
+          $values[] = [
+            'participant_id' => $this->getParticipantID(),
+            'price_field_name' => $priceField['price_field.name'],
+            'price_field_value_id' => !(bool) $priceField['price_field.is_enter_qty'] ? $value : NULL,
+            'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
+          ];
+        }
+      }
+
+      $additionalParticipantsPriceFields = \CRM_Remoteevent_RegistrationProfile::getPriceFields($event);
+      foreach ($this->getAdditionalParticipantsData() as $additionalParticipantNo => $additionalParticipant) {
+        foreach ($additionalParticipantsPriceFields as $priceField) {
+          $value = $this->submission['additional_' . $additionalParticipantNo . '_price_' . $priceField['price_field.name']] ?? NULL;
+          if (is_numeric($value)) {
+            $values[] = [
+              'participant_id' => $additionalParticipant['id'],
+              'price_field_name' => $priceField['price_field.name'],
+              'price_field_value_id' => !(bool) $priceField['price_field.is_enter_qty'] ? $value : NULL,
+              'qty' => (bool) $priceField['price_field.is_enter_qty'] ? $value : 1,
+            ];
+          }
+        }
+      }
+
+      return $values;
+    }
 }

--- a/Civi/RemoteParticipant/Event/Util/PaymentMethodUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/PaymentMethodUtil.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteParticipant\Event\Util;
+
+use CRM_Remoteevent_Localisation;
+
+class PaymentMethodUtil {
+
+  /**
+   * @phpstan-param array{
+   *   is_pay_later: bool|int,
+   * } $event
+   *
+   * @phpstan-return array<string, string>
+   */
+  public static function getPaymentMethodOptions(array $event, ?string $locale = NULL): array {
+    $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
+    $paymentMethods = [];
+
+    if ((bool) $event['is_pay_later']) {
+      $paymentMethods['pay_later'] = $event['pay_later_text'] ?? $l10n->ts('Pay Later');
+    }
+
+    if (self::civiSepaEnabled()) {
+      $paymentMethods['sepa'] = $l10n->ts('SEPA Direct Debit');
+    }
+
+    // TODO: Allow more custom payment methods that require sending back data
+    //       (instead of processing the payment on the remote environment).
+
+    return $paymentMethods;
+  }
+
+  public static function getPaymentMethodFields(array $event, string $paymentMethod, ?string $locale = NULL): array {
+    $l10n = CRM_Remoteevent_Localisation::getLocalisation($locale);
+    $fields = [];
+
+    switch ($paymentMethod) {
+      case 'sepa':
+        $fields['payment_method_sepa_account_holder'] = [
+          'type' => 'Text',
+          'name' => 'payment_method_sepa_account_holder',
+          'label' => $l10n->ts('Account Holder'),
+          'required' => FALSE,
+          'maxlength' => 34,
+          'parent' => 'payment_method',
+          'weight' => 1,
+          'dependencies' => [
+            [
+              'command' => 'hide',
+              'dependee_field' => 'payment_method',
+              'dependee_value' => 'sepa',
+            ],
+          ],
+        ];
+        $fields['payment_method_sepa_iban'] = [
+          'type' => 'Text',
+          'name' => 'payment_method_sepa_iban',
+          'label' => $l10n->ts('IBAN'),
+          'required' => TRUE,
+          'maxlength' => 34,
+          'parent' => 'payment_method',
+          'weight' => 1,
+          'dependencies' => [
+            [
+              'command' => 'hide',
+              'dependee_field' => 'payment_method',
+              'dependee_value' => 'sepa',
+            ],
+          ],
+        ];
+        $fields['payment_method_sepa_bic'] = [
+          'type' => 'Text',
+          'name' => 'payment_method_sepa_bic',
+          'label' => $l10n->ts('BIC'),
+          'required' => TRUE,
+          'maxlength' => 11,
+          'parent' => 'payment_method',
+          'weight' => 1,
+          'dependencies' => [
+            [
+              'command' => 'hide',
+              'dependee_field' => 'payment_method',
+              'dependee_value' => 'sepa',
+            ],
+          ],
+        ];
+        $fields['payment_method_sepa_bank_name'] = [
+          'type' => 'Text',
+          'name' => 'payment_method_sepa_bank_name',
+          'label' => $l10n->ts('Bank Name'),
+          'required' => FALSE,
+          'maxlength' => 64,
+          'parent' => 'payment_method',
+          'weight' => 1,
+          'dependencies' => [
+            [
+              'command' => 'hide',
+              'dependee_field' => 'payment_method',
+              'dependee_value' => 'sepa',
+            ],
+          ],
+        ];
+        break;
+    }
+
+    return $fields;
+  }
+
+  public static function civiSepaEnabled(): bool {
+    return (bool) \Civi\Api4\Extension::get(TRUE)
+      ->addWhere('key', '=', 'org.project60.sepa')
+      ->addWhere('status', '=', 'installed')
+      ->execute()
+      ->count();
+  }
+
+}

--- a/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
@@ -32,7 +32,7 @@ class PriceFieldUtil {
   /**
    * @phpstan-param array{id: int} $event
    *
-   * @phpstan-return array<int, array<string, mixed>>
+   * @phpstan-return array<int, array<string, string|int>>
    */
   public static function getPriceFields(array $event): array {
     return \Civi\Api4\Event::get(FALSE)

--- a/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
@@ -82,4 +82,20 @@ class PriceFieldUtil {
       ->getArrayCopy();
   }
 
+  /**
+   * @phpstan-param array{
+   *   id: int,
+   *   currency: string,
+   *   fee_label: string,
+   *   is_monetary: int,
+   * } $event
+   */
+  public static function hasRequiredPriceFields(array $event): bool {
+    return in_array(
+      TRUE,
+      array_column(PriceFieldUtil::getPriceFields($event), 'price_field.is_required'),
+      FALSE
+    );
+  }
+
 }

--- a/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
@@ -1,0 +1,85 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteParticipant\Event\Util;
+
+use Civi\Api4\PriceFieldValue;
+use CRM_Remoteevent_Localisation;
+
+class PriceFieldUtil {
+
+  /**
+   * @phpstan-var array<int, array<string, mixed>>
+   */
+  public static array $priceFieldValues = [];
+
+  /**
+   * @phpstan-param array{id: int} $event
+   *
+   * @phpstan-return array<int, array<string, mixed>>
+   */
+  public static function getPriceFields(array $event): array {
+    return \Civi\Api4\Event::get(FALSE)
+      ->addSelect(
+        'price_field.*',
+        'price_field_value.id',
+        'price_field_value.max_value',
+      )
+      ->addJoin(
+        'PriceSetEntity AS price_set_entity',
+        'INNER',
+        ['price_set_entity.entity_table', '=', '"civicrm_event"'],
+        ['price_set_entity.entity_id', '=', 'id']
+      )
+      ->addJoin(
+        'PriceSet AS price_set',
+        'INNER',
+        ['price_set.id', '=', 'price_set_entity.price_set_id'],
+        ['price_set.is_active', '=', 1]
+      )
+      ->addJoin(
+        'PriceField AS price_field',
+        'LEFT',
+        ['price_field.price_set_id', '=', 'price_set.id']
+      )
+      // For price fields with a selectable quantity, there is one single price field value; include its ID.
+      ->addJoin(
+        'PriceFieldValue AS price_field_value',
+        'LEFT',
+        ['price_field_value.price_field_id', '=', 'price_field.id'],
+        ['price_field.is_enter_qty', '=', TRUE]
+      )
+      ->addWhere('id', '=', $event['id'])
+      ->execute()
+      ->indexBy('price_field.id')
+      ->getArrayCopy();
+  }
+
+  /**
+   * @phpstan-return array<int, array<string, mixed>>
+   */
+  public static function getPriceFieldValues(int $priceFieldId): array {
+    return self::$priceFieldValues[$priceFieldId] ??= PriceFieldValue::get(FALSE)
+      ->addWhere('price_field_id', '=', $priceFieldId)
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
+  }
+
+}

--- a/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
+++ b/Civi/RemoteParticipant/Event/Util/PriceFieldUtil.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Civi\RemoteParticipant\Event\Util;
 
 use Civi\Api4\PriceFieldValue;
-use CRM_Remoteevent_Localisation;
 
 class PriceFieldUtil {
 

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -70,6 +70,17 @@ class ValidateEvent extends RemoteEvent {
     return $this->error_list;
   }
 
+  public function getAdditionalParticipantsCount(): int {
+    return array_reduce(
+      preg_grep('#^additional_([0-9]+)(_|$)#', array_keys($this->getSubmission())),
+      function(int $carry, string $item) {
+        $currentCount = (int) preg_filter('#^additional_([0-9]+)(.*?)$#', '$1', $item);
+        return max($carry, $currentCount);
+      },
+      0
+    );
+  }
+
   public function getRequestedParticipantCount(int $additionalParticipantsCount): int {
     $event = $this->getEvent();
     $submission = $this->getSubmission();

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -37,19 +37,19 @@ class ValidateEvent extends RemoteEvent {
   /**
    * @phpstan-return array<string, mixed>
    */
-  protected $submission;
+  protected array $submission;
+
+  public function __construct($submission_data, $error_list = []) {
+    $this->submission = $submission_data;
+    $this->error_list = $error_list;
+    $this->token_usages = ['invite', 'update'];
+  }
 
   /**
    * {@inheritDoc}
    */
   public function getQueryParameters(): array {
     return $this->submission;
-  }
-
-  public function __construct($submission_data, $error_list = []) {
-    $this->submission = $submission_data;
-    $this->error_list = $error_list;
-    $this->token_usages = ['invite', 'update'];
   }
 
   /**

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -18,6 +18,9 @@ declare(strict_types = 1);
 namespace Civi\RemoteParticipant\Event;
 
 use Civi\RemoteEvent;
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
+use Civi\RemoteParticipant\RegistrationEventFactory;
+use CRM_Remoteevent_RegistrationProfile;
 
 /**
  * Class ValidateEvent
@@ -32,58 +35,67 @@ class ValidateEvent extends RemoteEvent {
   public const NAME = 'civi.remoteevent.registration.validate';
 
   /**
-   * @var array holds the original RemoteParticipant.validate submission */
+   * @phpstan-return array<string, mixed>
+   */
   protected $submission;
 
+  /**
+   * {@inheritDoc}
+   */
+  public function getQueryParameters(): array {
+    return $this->submission;
+  }
+
   public function __construct($submission_data, $error_list = []) {
-    $this->submission  = $submission_data;
+    $this->submission = $submission_data;
     $this->error_list = $error_list;
     $this->token_usages = ['invite', 'update'];
   }
 
   /**
-   * Add an error to the given field
-   *
-   * @param string $field_name
-   *   field name
-   *
-   * @param string $error
-   *   error message to be displayed to the user
+   * @phpstan-return array<string, mixed>
    */
-  public function addValidationError($field_name, $error) {
-    // just pass to the underlying error system
-    $this->addError($error, $field_name);
+  public function getSubmission(): array {
+    return $this->submission;
+  }
+
+  public function addValidationError(string $fieldName, string $errorMessage): void {
+    $this->addError($errorMessage, $fieldName);
   }
 
   /**
-   * Modify Validation Errors
-   *
-   * @return array
-   *   $validation error list (reference!)
+   * @phpstan-return list<string>
    */
-  public function &modifyValidationErrors() {
-    // just pass to the underlying error system
+  public function &modifyValidationErrors(): array {
     return $this->error_list;
   }
 
-  /**
-   * Get the complete submission
-   *
-   * @return array
-   *   submission data
-   */
-  public function getSubmission() {
-    return $this->submission;
-  }
+  public function getRequestedParticipantCount(int $additionalParticipantsCount): int {
+    $event = $this->getEvent();
+    $submission = $this->getSubmission();
+    $priceFields = PriceFieldUtil::getPriceFields($event);
+    $maxRequestedParticipantCounts = [];
+    foreach (CRM_Remoteevent_RegistrationProfile::getPriceFieldsToValidate(
+      $priceFields,
+      $additionalParticipantsCount
+    ) as $fieldName => $priceFieldId) {
+      /** @var $participantNo 0 for the initial participant, 1-N for additional participants */
+      $participantNo = RegistrationEventFactory::getAdditionalParticipantNo($fieldName) ?? 0;
+      $priceField = $priceFields[$priceFieldId];
+      $priceFieldValues = PriceFieldUtil::getPriceFieldValues($priceField['price_field.id']);
+      $priceFieldValueId = $priceField['price_field.is_enter_qty']
+        ? array_key_first($priceFieldValues)
+        : (int) $submission[$fieldName];
 
-  /**
-   * Get the parameters of the original query
-   *
-   * @return array
-   *   parameters of the query
-   */
-  public function getQueryParameters() {
-    return $this->submission;
+      // For each participant (initial and additional), use the maximum count of participants in price fields to be used
+      // for this registration.
+      $maxRequestedParticipantCounts[$participantNo] = max(
+        $priceFieldValues[$priceFieldValueId]['count'] ?? 1,
+        $maxRequestedParticipantCounts[$participantNo]
+      );
+    }
+
+    return array_sum($maxRequestedParticipantCounts);
   }
 
 }

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -35,9 +35,8 @@ class ValidateEvent extends RemoteEvent {
   public const NAME = 'civi.remoteevent.registration.validate';
 
   /**
-   * @phpstan-return array<string, mixed>
-   */
-  protected array $submission;
+   * @var array<string, mixed> holds the original RemoteParticipant.validate submission */
+  protected $submission;
 
   public function __construct($submission_data, $error_list = []) {
     $this->submission = $submission_data;
@@ -59,14 +58,25 @@ class ValidateEvent extends RemoteEvent {
     return $this->submission;
   }
 
-  public function addValidationError(string $fieldName, string $errorMessage): void {
+  /**
+   * Add an error to the given field
+   *
+   * @param string $fieldName
+   *   field name
+   *
+   * @param string $errorMessage
+   *   error message to be displayed to the user
+   */
+  public function addValidationError($fieldName, $errorMessage): void {
+    // just pass to the underlying error system
     $this->addError($errorMessage, $fieldName);
   }
 
   /**
    * @phpstan-return list<string>
+   *   $validation error list (reference!)
    */
-  public function &modifyValidationErrors(): array {
+  public function &modifyValidationErrors() {
     return $this->error_list;
   }
 

--- a/Civi/RemoteParticipant/Event/ValidateEvent.php
+++ b/Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -100,7 +100,7 @@ class ValidateEvent extends RemoteEvent {
       $priceFields,
       $additionalParticipantsCount
     ) as $fieldName => $priceFieldId) {
-      /** @var $participantNo 0 for the initial participant, 1-N for additional participants */
+      /** @var int $participantNo 0 for the initial participant, 1-N for additional participants */
       $participantNo = RegistrationEventFactory::getAdditionalParticipantNo($fieldName) ?? 0;
       $priceField = $priceFields[$priceFieldId];
       $priceFieldValues = PriceFieldUtil::getPriceFieldValues($priceField['price_field.id']);

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -21,6 +21,7 @@ namespace Civi\RemoteParticipant;
 
 use Civi\RemoteParticipant\Event\RegistrationEvent;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
+use CRM_Remoteevent_RegistrationProfile;
 
 final class RegistrationEventFactory {
 
@@ -60,11 +61,10 @@ final class RegistrationEventFactory {
       }
     }
 
-    // Assign default role for new participants only.
-    if (NULL === $registrationEvent->getParticipantID()) {
-      $participantData['role_id'] ??= $this->getDefaultRoleId($event);
-    }
-    $participantData['event_id'] = $submissionData['event_id'];
+    public function createRegistrationEvent(array $submissionData): RegistrationEvent {
+        $registrationEvent = new RegistrationEvent($submissionData);
+        $profile = CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
+        $event = $registrationEvent->getEvent();
 
     $profile->modifyContactData($contactData);
 
@@ -121,52 +121,84 @@ final class RegistrationEventFactory {
       }
     }
 
-    if ([] === $additionalParticipantsData && [] === $additionalContactsData) {
-      return;
+    /**
+     * Handles additional participants' data in the submission data and sets the
+     * resulting data in the event.
+     */
+    private function handleAdditionalParticipants(RegistrationEvent $registrationEvent, CRM_Remoteevent_RegistrationProfile $profile): void {
+        $event = $registrationEvent->getEvent();
+
+        $additionalContactsData = [];
+        $additionalParticipantsData = [];
+
+        $submissionData = $registrationEvent->getSubmission();
+        foreach ($profile->getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
+            $participantNo = CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantNo($fieldKey);
+            if (null !== $participantNo && array_key_exists($fieldKey, $submissionData)) {
+                $entityNames = (array)($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
+                $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
+                $value = isset($fieldSpec['value_callback'])
+                  ? $fieldSpec['value_callback']($submissionData[$fieldKey], $submissionData)
+                  : $submissionData[$fieldKey];
+
+                if ('File' === $fieldSpec['type'] && NULL !== $value) {
+                    $value = $this->filePersister->persistFileFromForm($value, NULL, $registrationEvent->getContactId());
+                }
+
+                if (in_array('Contact', $entityNames, true)) {
+                    $additionalContactsData[$participantNo][$entityFieldName] = $value;
+                }
+                if (in_array('Participant', $entityNames, true)) {
+                    $additionalParticipantsData[$participantNo][$entityFieldName] = $value;
+                }
+            }
+        }
+
+        if ([] === $additionalParticipantsData && [] === $additionalContactsData) {
+            return;
+        }
+
+        $additionalParticipantsProfile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+          $event['event_remote_registration.remote_registration_additional_participants_profile']
+        );
+        $additionalParticipantCount = 0;
+        foreach ($additionalContactsData as $participantNo => &$contactData) {
+            $additionalParticipantCount++;
+            $additionalParticipantsProfile->modifyContactData($contactData);
+            $contactData['contact_type'] ??= 'Individual';
+            $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
+            $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
+            $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
+
+            // Check for waitlist.
+            // TODO: merge with code in \CRM_Remoteevent_RegistrationProfile::validateSubmission().
+            if (
+                !empty($event['max_participants'])
+                && !empty($event['has_waitlist'])
+                && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+                && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
+                // Primary participant has not yet been created or its status is not counted, thus add 1.
+                + 1
+                + $additionalParticipantCount
+                - $event['max_participants'] > 0
+            ) {
+                $additionalParticipantsData[$participantNo]['status_id.name'] = 'On waitlist';
+            }
+            // Check if registration requires approval.
+            elseif (!empty($event['requires_approval'])) {
+                $additionalParticipantsData[$participantNo]['status_id.name'] = 'Awaiting approval';
+            }
+        }
+
+        $registrationEvent->setAdditionalContactsData($additionalContactsData);
+        $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
     }
 
-    $additionalParticipantsProfile = \CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
-      $event['event_remote_registration.remote_registration_additional_participants_profile']
-    );
-    $additionalParticipantCount = 0;
-    foreach ($additionalContactsData as $participantNo => &$contactData) {
-      $additionalParticipantCount++;
-      $additionalParticipantsProfile->modifyContactData($contactData);
-      $contactData['contact_type'] ??= 'Individual';
-      // phpcs:ignore Generic.Files.LineLength.TooLong
-      $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
-      $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
-      $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
-
-      // Check for waitlist.
-      // TODO: merge with code in \CRM_Remoteevent_RegistrationProfile::validateSubmission().
-      if (
-        !empty($event['max_participants'])
-        && !empty($event['has_waitlist'])
-        && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
-        && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
-        // Primary participant has not yet been created or its status is not counted, thus add 1.
-        // phpcs:ignore Drupal.Formatting.SpaceUnaryOperator.PlusMinus
-        + 1
-        + $additionalParticipantCount
-        - $event['max_participants'] > 0
-      ) {
-        $additionalParticipantsData[$participantNo]['status_id.name'] = 'On waitlist';
-      }
-      // Check if registration requires approval.
-      elseif (!empty($event['requires_approval'])) {
-        $additionalParticipantsData[$participantNo]['status_id.name'] = 'Awaiting approval';
-      }
-    }
-
-    $registrationEvent->setAdditionalContactsData($additionalContactsData);
-    $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
-  }
-
-  private function getAdditionalParticipantNo(string $fieldKey): ?int {
-    $matches = [];
-    if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
-      return (int) $matches[1];
+  /**
+     * @param array<string, mixed> $event
+     */
+    private function getDefaultRoleId(array $event): int {
+        return (int) ($event['default_role_id'] ?: 1); // 1 = Attendee
     }
 
     return NULL;

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -32,15 +32,17 @@ final class RegistrationEventFactory {
     $this->filePersister = $filePersister;
   }
 
+  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
   public function createRegistrationEvent(array $submissionData): RegistrationEvent {
     $registrationEvent = new RegistrationEvent($submissionData);
-    $profile = CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
+    $profile = \CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
     $event = $registrationEvent->getEvent();
 
     $contactData = [];
     $participantData = [];
     foreach ($profile->getFields() as $fieldKey => $fieldSpec) {
       if (array_key_exists($fieldKey, $submissionData)) {
+        // @phpstan-ignore method.deprecated
         $entityNames = (array) ($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
         $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
         $value = isset($fieldSpec['value_callback'])
@@ -81,16 +83,16 @@ final class RegistrationEventFactory {
    */
   private function getDefaultRoleId(array $event): int {
     // 1 = Attendee
-    return (int) ($event['default_role_id'] ?: 1);
+    return is_numeric($event['default_role_id'] ?? NULL) ? (int) $event['default_role_id'] : 1;
   }
 
   /**
    * Handles additional participants' data in the submission data and sets the
    * resulting data in the event.
    */
-  private function handleAdditionalParticipants(
-    RegistrationEvent $registrationEvent,
-    CRM_Remoteevent_RegistrationProfile $profile
+  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
+  private function handleAdditionalParticipants(RegistrationEvent $registrationEvent,
+    \CRM_Remoteevent_RegistrationProfile $profile
   ): void {
     $event = $registrationEvent->getEvent();
 
@@ -101,6 +103,7 @@ final class RegistrationEventFactory {
     foreach (CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
       $participantNo = self::getAdditionalParticipantNo($fieldKey);
       if (NULL !== $participantNo && array_key_exists($fieldKey, $submissionData)) {
+        // @phpstan-ignore method.deprecated
         $entityNames = (array) ($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
         $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
         $value = isset($fieldSpec['value_callback'])
@@ -124,7 +127,7 @@ final class RegistrationEventFactory {
       return;
     }
 
-    $additionalParticipantsProfile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+    $additionalParticipantsProfile = \CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
       $event['event_remote_registration.remote_registration_additional_participants_profile']
     );
     $additionalParticipantCount = 0;
@@ -145,7 +148,8 @@ final class RegistrationEventFactory {
         && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
         && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
         // Primary participant has not yet been created or its status is not counted, thus add 1.
-        // TODO: This has to be dependent on price field participant counts, which might be more than 1 per participant.
+        // TODO: This has to be dependent on price field participant counts, which might be more than 1 per participant.                
+        // phpcs:ignore Drupal.Formatting.SpaceUnaryOperator.PlusMinus        
         + 1
         + $additionalParticipantCount
         - $event['max_participants'] > 0
@@ -162,7 +166,7 @@ final class RegistrationEventFactory {
     $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
   }
 
-  public static function getAdditionalParticipantNo(string $fieldKey): ?int {
+  private function getAdditionalParticipantNo(string $fieldKey): ?int {
     $matches = [];
     if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
       return (int) $matches[1];

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -20,7 +20,6 @@ declare(strict_types = 1);
 namespace Civi\RemoteParticipant;
 
 use Civi\RemoteParticipant\Event\RegistrationEvent;
-use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
 use CRM_Remoteevent_RegistrationProfile;
 
@@ -148,7 +147,7 @@ final class RegistrationEventFactory {
         && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
         && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
         // Primary participant has not yet been created or its status is not counted, thus add 1.
-        // TODO: This has to be dependent on price field participant counts, which might be more than 1 per participant.                
+        // TODO: This has to be dependent on price field participant counts, which might be more than 1 per participant.
         // phpcs:ignore Drupal.Formatting.SpaceUnaryOperator.PlusMinus        
         + 1
         + $additionalParticipantCount

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -166,7 +166,7 @@ final class RegistrationEventFactory {
     $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
   }
 
-  private function getAdditionalParticipantNo(string $fieldKey): ?int {
+  public static function getAdditionalParticipantNo(string $fieldKey): ?int {
     $matches = [];
     if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
       return (int) $matches[1];

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteParticipant;
 
 use Civi\RemoteParticipant\Event\RegistrationEvent;
+use Civi\RemoteParticipant\Event\Util\PriceFieldUtil;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
 use CRM_Remoteevent_RegistrationProfile;
 
@@ -31,17 +32,15 @@ final class RegistrationEventFactory {
     $this->filePersister = $filePersister;
   }
 
-  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
   public function createRegistrationEvent(array $submissionData): RegistrationEvent {
     $registrationEvent = new RegistrationEvent($submissionData);
-    $profile = \CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
+    $profile = CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
     $event = $registrationEvent->getEvent();
 
     $contactData = [];
     $participantData = [];
     foreach ($profile->getFields() as $fieldKey => $fieldSpec) {
       if (array_key_exists($fieldKey, $submissionData)) {
-        // @phpstan-ignore method.deprecated
         $entityNames = (array) ($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
         $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
         $value = isset($fieldSpec['value_callback'])
@@ -61,10 +60,11 @@ final class RegistrationEventFactory {
       }
     }
 
-    public function createRegistrationEvent(array $submissionData): RegistrationEvent {
-        $registrationEvent = new RegistrationEvent($submissionData);
-        $profile = CRM_Remoteevent_RegistrationProfile::getProfile($registrationEvent);
-        $event = $registrationEvent->getEvent();
+    // Assign default role for new participants only.
+    if (NULL === $registrationEvent->getParticipantID()) {
+      $participantData['role_id'] ??= $this->getDefaultRoleId($event);
+    }
+    $participantData['event_id'] = $submissionData['event_id'];
 
     $profile->modifyContactData($contactData);
 
@@ -81,16 +81,16 @@ final class RegistrationEventFactory {
    */
   private function getDefaultRoleId(array $event): int {
     // 1 = Attendee
-    return is_numeric($event['default_role_id'] ?? NULL) ? (int) $event['default_role_id'] : 1;
+    return (int) ($event['default_role_id'] ?: 1);
   }
 
   /**
    * Handles additional participants' data in the submission data and sets the
    * resulting data in the event.
    */
-  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
-  private function handleAdditionalParticipants(RegistrationEvent $registrationEvent,
-    \CRM_Remoteevent_RegistrationProfile $profile
+  private function handleAdditionalParticipants(
+    RegistrationEvent $registrationEvent,
+    CRM_Remoteevent_RegistrationProfile $profile
   ): void {
     $event = $registrationEvent->getEvent();
 
@@ -98,10 +98,9 @@ final class RegistrationEventFactory {
     $additionalParticipantsData = [];
 
     $submissionData = $registrationEvent->getSubmission();
-    foreach ($profile->getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
-      $participantNo = $this->getAdditionalParticipantNo($fieldKey);
+    foreach (CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
+      $participantNo = self::getAdditionalParticipantNo($fieldKey);
       if (NULL !== $participantNo && array_key_exists($fieldKey, $submissionData)) {
-        // @phpstan-ignore method.deprecated
         $entityNames = (array) ($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
         $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
         $value = isset($fieldSpec['value_callback'])
@@ -121,86 +120,53 @@ final class RegistrationEventFactory {
       }
     }
 
-    /**
-     * Handles additional participants' data in the submission data and sets the
-     * resulting data in the event.
-     */
-    private function handleAdditionalParticipants(RegistrationEvent $registrationEvent, CRM_Remoteevent_RegistrationProfile $profile): void {
-        $event = $registrationEvent->getEvent();
-
-        $additionalContactsData = [];
-        $additionalParticipantsData = [];
-
-        $submissionData = $registrationEvent->getSubmission();
-        foreach ($profile->getAdditionalParticipantsFields($event) as $fieldKey => $fieldSpec) {
-            $participantNo = CRM_Remoteevent_RegistrationProfile::getAdditionalParticipantNo($fieldKey);
-            if (null !== $participantNo && array_key_exists($fieldKey, $submissionData)) {
-                $entityNames = (array)($fieldSpec['entity_name'] ?? $profile->getFieldEntities($fieldKey));
-                $entityFieldName = $fieldSpec['entity_field_name'] ?? $fieldKey;
-                $value = isset($fieldSpec['value_callback'])
-                  ? $fieldSpec['value_callback']($submissionData[$fieldKey], $submissionData)
-                  : $submissionData[$fieldKey];
-
-                if ('File' === $fieldSpec['type'] && NULL !== $value) {
-                    $value = $this->filePersister->persistFileFromForm($value, NULL, $registrationEvent->getContactId());
-                }
-
-                if (in_array('Contact', $entityNames, true)) {
-                    $additionalContactsData[$participantNo][$entityFieldName] = $value;
-                }
-                if (in_array('Participant', $entityNames, true)) {
-                    $additionalParticipantsData[$participantNo][$entityFieldName] = $value;
-                }
-            }
-        }
-
-        if ([] === $additionalParticipantsData && [] === $additionalContactsData) {
-            return;
-        }
-
-        $additionalParticipantsProfile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
-          $event['event_remote_registration.remote_registration_additional_participants_profile']
-        );
-        $additionalParticipantCount = 0;
-        foreach ($additionalContactsData as $participantNo => &$contactData) {
-            $additionalParticipantCount++;
-            $additionalParticipantsProfile->modifyContactData($contactData);
-            $contactData['contact_type'] ??= 'Individual';
-            $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
-            $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
-            $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
-
-            // Check for waitlist.
-            // TODO: merge with code in \CRM_Remoteevent_RegistrationProfile::validateSubmission().
-            if (
-                !empty($event['max_participants'])
-                && !empty($event['has_waitlist'])
-                && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
-                && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
-                // Primary participant has not yet been created or its status is not counted, thus add 1.
-                + 1
-                + $additionalParticipantCount
-                - $event['max_participants'] > 0
-            ) {
-                $additionalParticipantsData[$participantNo]['status_id.name'] = 'On waitlist';
-            }
-            // Check if registration requires approval.
-            elseif (!empty($event['requires_approval'])) {
-                $additionalParticipantsData[$participantNo]['status_id.name'] = 'Awaiting approval';
-            }
-        }
-
-        $registrationEvent->setAdditionalContactsData($additionalContactsData);
-        $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
+    if ([] === $additionalParticipantsData && [] === $additionalContactsData) {
+      return;
     }
 
-  /**
-     * @param array<string, mixed> $event
-     */
-    private function getDefaultRoleId(array $event): int {
-        return (int) ($event['default_role_id'] ?: 1); // 1 = Attendee
+    $additionalParticipantsProfile = CRM_Remoteevent_RegistrationProfile::getRegistrationProfile(
+      $event['event_remote_registration.remote_registration_additional_participants_profile']
+    );
+    $additionalParticipantCount = 0;
+    foreach ($additionalContactsData as $participantNo => &$contactData) {
+      $additionalParticipantCount++;
+      $additionalParticipantsProfile->modifyContactData($contactData);
+      $contactData['contact_type'] ??= 'Individual';
+      $contactData['xcm_profile']
+        = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
+      $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
+      $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
+
+      // Check for waitlist.
+      // TODO: merge with code in \CRM_Remoteevent_RegistrationProfile::validateSubmission().
+      if (
+        !empty($event['max_participants'])
+        && !empty($event['has_waitlist'])
+        && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+        && \CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
+        // Primary participant has not yet been created or its status is not counted, thus add 1.
+        // TODO: This has to be dependent on price field participant counts, which might be more than 1 per participant.
+        + 1
+        + $additionalParticipantCount
+        - $event['max_participants'] > 0
+      ) {
+        $additionalParticipantsData[$participantNo]['status_id.name'] = 'On waitlist';
+      }
+      // Check if registration requires approval.
+      elseif (!empty($event['requires_approval'])) {
+        $additionalParticipantsData[$participantNo]['status_id.name'] = 'Awaiting approval';
+      }
     }
 
+    $registrationEvent->setAdditionalContactsData($additionalContactsData);
+    $registrationEvent->setAdditionalParticipantsData($additionalParticipantsData);
+  }
+
+  public static function getAdditionalParticipantNo(string $fieldKey): ?int {
+    $matches = [];
+    if (1 === preg_match('#^additional_([0-9]+)_(.*?)$#', $fieldKey, $matches)) {
+      return (int) $matches[1];
+    }
     return NULL;
   }
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ request (e.g., the current language of the frontend)
 ## Requirements
 
 + PHP v7.0+
-+ CiviCRM 5.61
++ CiviCRM 5.76
 + Dependency on the CiviCRM Extension CiviRemote Tools
 + Dependency on the CiviCRM Extension Extended Contact Matcher
 + A system to serve as your public interface, such as an external website

--- a/README_DE.md
+++ b/README_DE.md
@@ -69,7 +69,7 @@ TODO: Vollständige Merkmalliste
 ## Anforderungen
 
 * PHP ab Version 7.0
-* CiviCRM 5.0
+* CiviCRM 5.76
 * Abhängigkeit zur CiviCRM-Erweiterung "Remote Tools" (de.systopia.remotetools)
 * Abhängigkeit zur CiviCRM-Erweiterung "Extended Contact Matcher" (
   de.systopia.xcm)

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "civicrm/civicrm-packages": ">=6.2",
         "systopia/de.systopia.remotetools": "^1.2"
     },
-    "suggest": {
-        "systopia/de.systopia.eventmessages": "Send emails to participants"
-    },
     "autoload": {
         "classmap": ["ComposerHelper.php"]
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ built-in forms, such as:
 ## Requirements
 
 + PHP v7.0+
-+ CiviCRM 5.61
++ CiviCRM 5.76
 + Dependency on the CiviCRM Extension CiviRemote Tools
 + Dependency on the CiviCRM Extension Extended Contact Matcher
 + A system to serve as your public interface, such as an external website

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1944,7 +1944,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 35
+			count: 33
 			path: CRM/Remoteevent/Registration.php
 
 		-
@@ -2091,18 +2091,6 @@ parameters:
 			path: CRM/Remoteevent/Registration.php
 
 		-
-			message: '#^Method CRM_Remoteevent_Registration\:\:invalidateRegistrationCache\(\) has parameter \$contact_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Remoteevent/Registration.php
-
-		-
-			message: '#^Method CRM_Remoteevent_Registration\:\:invalidateRegistrationCache\(\) has parameter \$event_id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Remoteevent/Registration.php
-
-		-
 			message: '#^Method CRM_Remoteevent_Registration\:\:isRegistrationSuspended\(\) has parameter \$event_data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2175,12 +2163,6 @@ parameters:
 			path: CRM/Remoteevent/Registration.php
 
 		-
-			message: '#^Parameter \#1 \$profile_name of static method CRM_Xcm_Configuration\:\:getConfigProfile\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Remoteevent/Registration.php
-
-		-
 			message: '#^Part \$profile_name \(mixed\) of encapsed string cannot be cast to string\.$#'
 			identifier: encapsedStringPart.nonString
 			count: 1
@@ -2195,16 +2177,6 @@ parameters:
 		-
 			message: '#^Property CRM_Remoteevent_Registration\:\:\$cached_registration_event_ids type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: CRM/Remoteevent/Registration.php
-
-		-
-			message: '#^Thrown exceptions in a catch block must bundle the previous exception \(see throw statement line 533\)\.$#'
-			count: 1
-			path: CRM/Remoteevent/Registration.php
-
-		-
-			message: '#^Thrown exceptions in a catch block must bundle the previous exception \(see throw statement line 549\)\.$#'
 			count: 1
 			path: CRM/Remoteevent/Registration.php
 
@@ -2259,7 +2231,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 11
+			count: 13
 			path: CRM/Remoteevent/RegistrationProfile.php
 
 		-
@@ -2286,12 +2258,6 @@ parameters:
 
 		-
 			message: '#^Method CRM_Remoteevent_RegistrationProfile\:\:addDefaultValues\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Remoteevent/RegistrationProfile.php
-
-		-
-			message: '#^Method CRM_Remoteevent_RegistrationProfile\:\:addProfileData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: CRM/Remoteevent/RegistrationProfile.php
@@ -2507,18 +2473,6 @@ parameters:
 			path: CRM/Remoteevent/RegistrationProfile.php
 
 		-
-			message: '#^Parameter \#1 \$array of function array_reduce expects array, array\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Remoteevent/RegistrationProfile.php
-
-		-
-			message: '#^Parameter \#1 \$event of method CRM_Remoteevent_RegistrationProfile\:\:getAdditionalParticipantsFields\(\) expects array, array\<string, mixed\>\|null given\.$#'
-			identifier: argument.type
-			count: 2
-			path: CRM/Remoteevent/RegistrationProfile.php
-
-		-
 			message: '#^Parameter \#1 \$event_id of static method CRM_Remoteevent_Registration\:\:getRegistrationCount\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -2599,12 +2553,6 @@ parameters:
 		-
 			message: '#^Cannot access offset ''city''\|''country_id''\|''postal_code''\|''state_province_id''\|''street_address''\|''supplemental_address_1''\|''supplemental_address_2'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: CRM/Remoteevent/RegistrationProfile/Standard3.php
-
-		-
-			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
-			identifier: empty.notAllowed
 			count: 1
 			path: CRM/Remoteevent/RegistrationProfile/Standard3.php
 
@@ -4045,12 +3993,6 @@ parameters:
 			path: Civi/RemoteParticipant/Event/GetParticipantFormEventBase.php
 
 		-
-			message: '#^PHPDoc type array of property Civi\\RemoteParticipant\\Event\\GetParticipantFormEventBase\:\:\$result is not the same as PHPDoc type array\|null of overridden property Civi\\RemoteToolsRequest\:\:\$result\.$#'
-			identifier: property.phpDocType
-			count: 1
-			path: Civi/RemoteParticipant/Event/GetParticipantFormEventBase.php
-
-		-
 			message: '#^Property Civi\\RemoteEvent\:\:\$participant_id \(int\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -4363,31 +4305,7 @@ parameters:
 			path: Civi/RemoteParticipant/Event/ValidateEvent.php
 
 		-
-			message: '#^Method Civi\\RemoteParticipant\\Event\\ValidateEvent\:\:addValidationError\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: Civi/RemoteParticipant/Event/ValidateEvent.php
-
-		-
 			message: '#^Method Civi\\RemoteParticipant\\Event\\ValidateEvent\:\:getQueryParameters\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/RemoteParticipant/Event/ValidateEvent.php
-
-		-
-			message: '#^Method Civi\\RemoteParticipant\\Event\\ValidateEvent\:\:getSubmission\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/RemoteParticipant/Event/ValidateEvent.php
-
-		-
-			message: '#^Method Civi\\RemoteParticipant\\Event\\ValidateEvent\:\:modifyValidationErrors\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: Civi/RemoteParticipant/Event/ValidateEvent.php
-
-		-
-			message: '#^Property Civi\\RemoteParticipant\\Event\\ValidateEvent\:\:\$submission type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: Civi/RemoteParticipant/Event/ValidateEvent.php
@@ -4449,12 +4367,6 @@ parameters:
 		-
 			message: '#^Offset ''event_remote_registration\.remote_registration_additional_participants_xcm_profile'' might not exist on array\<string, mixed\>\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 1
-			path: Civi/RemoteParticipant/RegistrationEventFactory.php
-
-		-
-			message: '#^Parameter \#1 \$event of method CRM_Remoteevent_RegistrationProfile\:\:getAdditionalParticipantsFields\(\) expects array, array\<string, mixed\>\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: Civi/RemoteParticipant/RegistrationEventFactory.php
 
@@ -5580,7 +5492,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''values'' on array\|int\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 5
 			path: tests/phpunit/CRM/Remoteevent/GetFormTest.php
 
 		-
@@ -5998,12 +5910,6 @@ parameters:
 			path: tests/phpunit/CRM/Remoteevent/TestBase.php
 
 		-
-			message: '#^Method CRM_Remoteevent_TestBase\:\:assertParticipantStatus\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/phpunit/CRM/Remoteevent/TestBase.php
-
-		-
 			message: '#^Method CRM_Remoteevent_TestBase\:\:callRemoteEventAPI\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -6198,12 +6104,6 @@ parameters:
 		-
 			message: '#^Method CRM_Remoteevent_TestBase\:\:registerRemote\(\) has parameter \$participant_details with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: tests/phpunit/CRM/Remoteevent/TestBase.php
-
-		-
-			message: '#^Method CRM_Remoteevent_TestBase\:\:setSpeakerRoles\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/phpunit/CRM/Remoteevent/TestBase.php
 

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -7,6 +7,7 @@ parameters:
 		- ci/vendor/civicrm/civicrm-core/CRM/
 		- ci/vendor/civicrm/civicrm-core/Civi/
 		- ci/vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
+		- ci/vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
 	bootstrapFiles:
 		- ci/vendor/autoload.php
 		- ci/vendor/civicrm/civicrm-core/api/Exception.php

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -8,10 +8,13 @@ parameters:
 		- ci/vendor/civicrm/civicrm-core/Civi/
 		- ci/vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
 		- ci/vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
+		- ci/vendor/civicrm/civicrm-core/ext/legacycustomsearches/CRM/
+		- ci/vendor/civicrm/civicrm-packages/HTML/
+		- ci/vendor/civicrm/civicrm-packages/DB/
 	bootstrapFiles:
 		- ci/vendor/autoload.php
 		- ci/vendor/civicrm/civicrm-core/api/Exception.php
-	# Because we test with different versions in CI we have unmatched errors
+	# Because we test with different versions in CI we may have unmatched errors.
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		# Errors we get when using "prefer-lowest"

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -3,17 +3,14 @@ includes:
 
 parameters:
 	scanDirectories:
-		- vendor/civicrm/civicrm-core/api
-		- vendor/civicrm/civicrm-core/CRM
-		- vendor/civicrm/civicrm-core/Civi
-		- vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4
-		- vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4
-		- vendor/civicrm/civicrm-core/ext/legacycustomsearches/CRM
-		- vendor/civicrm/civicrm-packages/HTML
-		- vendor/civicrm/civicrm-packages/DB
+		- ci/vendor/civicrm/civicrm-core/api/
+		- ci/vendor/civicrm/civicrm-core/CRM/
+		- ci/vendor/civicrm/civicrm-core/Civi/
+		- ci/vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
 	bootstrapFiles:
-		- vendor/autoload.php
-	# Because we test with different versions in CI we may have unmatched errors.
+		- ci/vendor/autoload.php
+		- ci/vendor/civicrm/civicrm-core/api/Exception.php
+	# Because we test with different versions in CI we have unmatched errors
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		# Errors we get when using "prefer-lowest"

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -2,18 +2,8 @@ includes:
 	- phpstan.neon.dist
 
 parameters:
-	scanDirectories:
-		- ci/vendor/civicrm/civicrm-core/api/
-		- ci/vendor/civicrm/civicrm-core/CRM/
-		- ci/vendor/civicrm/civicrm-core/Civi/
-		- ci/vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
-		- ci/vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
-		- ci/vendor/civicrm/civicrm-core/ext/legacycustomsearches/CRM/
-		- ci/vendor/civicrm/civicrm-packages/HTML/
-		- ci/vendor/civicrm/civicrm-packages/DB/
 	bootstrapFiles:
-		- ci/vendor/autoload.php
-		- ci/vendor/civicrm/civicrm-core/api/Exception.php
+		- vendor/autoload.php
 	# Because we test with different versions in CI we may have unmatched errors.
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
@@ -21,6 +11,3 @@ parameters:
 
 		# Required with symfony/event-dispatcher <4.4.27
 		- '#::getSubscribedEvents\(\) return type has no value type specified in iterable type array.$#'
-
-		# Required with symfony/dependency-injection < 6.3.0
-		- '#^Method Civi\\RemoteEvent\\CompilerPass\:\:process\(\) has no return type specified\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,14 +16,12 @@ parameters:
 		- remoteevent.civix.php
 		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework/TestCase.php
 	scanDirectories:
-		- ../action-provider/Civi
-		- ../de.systopia.xcm/CRM
-		- ../de.systopia.eventmessages/Civi
 		- ../de.systopia.remotetools/Civi
 		- ../de.systopia.remotetools/CRM
 		- ../de.systopia.eventmessages/Civi/EventMessages
 		- ../de.systopia.xcm/CRM
 		- ../action-provider/Civi
+    - ../de.systopia.xportx/CRM
 		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework
 		- mixin
 	bootstrapFiles:
@@ -40,7 +38,7 @@ parameters:
 			- civiExit
 			- redirect
 		CRM_Queue_Runner:
-			- runAllViaWeb
+		  - runAllViaWeb
 	checkTooWideReturnTypesInProtectedAndPublicMethods: true
 	checkUninitializedProperties: true
 	checkMissingCallableSignature: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,7 +21,9 @@ parameters:
 		- ../de.systopia.eventmessages/Civi
 		- ../de.systopia.remotetools/Civi
 		- ../de.systopia.remotetools/CRM
-		- ../de.systopia.xportx/CRM
+		- ../de.systopia.eventmessages/Civi/EventMessages
+		- ../de.systopia.xcm/CRM
+		- ../action-provider/Civi
 		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework
 		- mixin
 	bootstrapFiles:
@@ -53,4 +55,5 @@ parameters:
 	ignoreErrors:
 		# Note paths are prefixed with "*/" to work with inspections in PHPStorm because of:
 		# https://youtrack.jetbrains.com/issue/WI-63891/PHPStan-ignoreErrors-configuration-isnt-working-with-inspections
+		- '#^Parameter \#3 \$bridge of method Civi\\Api4\\Generic\\DAOGetAction::addJoin\(\) expects string\|null, array<int, string> given.$#'
 	tmpDir: .phpstan

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,7 +21,9 @@ parameters:
 		- ../de.systopia.eventmessages/Civi/EventMessages
 		- ../de.systopia.xcm/CRM
 		- ../action-provider/Civi
-    - ../de.systopia.xportx/CRM
+		- ../de.systopia.xportx/CRM
+		- ../org.project60.sepa/CRM/Sepa/Logic
+		- ../org.project60.sepa/Civi/Api4
 		- tools/phpunit/vendor/bin/.phpunit/phpunit/src/Framework
 		- mixin
 	bootstrapFiles:

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -12,6 +12,25 @@ parameters:
 		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
 		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
 		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/legacycustomsearches/CRM/
+		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML/
+		- {VENDOR_DIR}/civicrm/civicrm-packages/DB/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php
 		- {VENDOR_DIR}/civicrm/civicrm-core/api/Exception.php
+
+# For installations without composer (e.g. as WordPress plugin),
+# replace the parameters section above with the following configuration:
+#
+#parameters:
+#	scanDirectories:
+#		- {CIVICRM_DIR}/api
+#		- {CIVICRM_DIR}/CRM
+#		- {CIVICRM_DIR}/Civi
+#		- {CIVICRM_DIR}/ext/civi_event/Civi/Api4
+#		- {CIVICRM_DIR}/ext/civi_contribute/Civi/Api4
+#		- {CIVICRM_DIR}/ext/legacycustomsearches/CRM
+#		- {CIVICRM_DIR}/packages/HTML
+#		- {CIVICRM_DIR}/packages/DB
+#	bootstrapFiles:
+#		- {CIVICRM_DIR}/vendor/autoload.php

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -6,31 +6,5 @@ includes:
 	- phpstan.neon.dist
 
 parameters:
-	scanDirectories:
-		- {VENDOR_DIR}/civicrm/civicrm-core/api/
-		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
-		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/legacycustomsearches/CRM/
-		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML/
-		- {VENDOR_DIR}/civicrm/civicrm-packages/DB/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php
-		- {VENDOR_DIR}/civicrm/civicrm-core/api/Exception.php
-
-# For installations without composer (e.g. as WordPress plugin),
-# replace the parameters section above with the following configuration:
-#
-#parameters:
-#	scanDirectories:
-#		- {CIVICRM_DIR}/api
-#		- {CIVICRM_DIR}/CRM
-#		- {CIVICRM_DIR}/Civi
-#		- {CIVICRM_DIR}/ext/civi_event/Civi/Api4
-#		- {CIVICRM_DIR}/ext/civi_contribute/Civi/Api4
-#		- {CIVICRM_DIR}/ext/legacycustomsearches/CRM
-#		- {CIVICRM_DIR}/packages/HTML
-#		- {CIVICRM_DIR}/packages/DB
-#	bootstrapFiles:
-#		- {CIVICRM_DIR}/vendor/autoload.php

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -7,29 +7,10 @@ includes:
 
 parameters:
 	scanDirectories:
-		- {VENDOR_DIR}/civicrm/civicrm-core/api
-		- {VENDOR_DIR}/civicrm/civicrm-core/CRM
-		- {VENDOR_DIR}/civicrm/civicrm-core/Civi
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/legacycustomsearches/CRM
-		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML
-		- {VENDOR_DIR}/civicrm/civicrm-packages/DB
+		- {VENDOR_DIR}/civicrm/civicrm-core/api/
+		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
+		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php
-
-# For installations without composer (e.g. as WordPress plugin),
-# replace the parameters section above with the following configuration:
-#
-#parameters:
-#	scanDirectories:
-#		- {CIVICRM_DIR}/api
-#		- {CIVICRM_DIR}/CRM
-#		- {CIVICRM_DIR}/Civi
-#		- {CIVICRM_DIR}/ext/civi_event/Civi/Api4
-#		- {CIVICRM_DIR}/ext/civi_contribute/Civi/Api4
-#		- {CIVICRM_DIR}/ext/legacycustomsearches/CRM
-#		- {CIVICRM_DIR}/packages/HTML
-#		- {CIVICRM_DIR}/packages/DB
-#	bootstrapFiles:
-#		- {CIVICRM_DIR}/vendor/autoload.php
+		- {VENDOR_DIR}/civicrm/civicrm-core/api/Exception.php

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -11,6 +11,7 @@ parameters:
 		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
 		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
 		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
 	bootstrapFiles:
 		- {VENDOR_DIR}/autoload.php
 		- {VENDOR_DIR}/civicrm/civicrm-core/api/Exception.php

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -301,11 +301,10 @@ function remoteevent_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_container()
+ * Implements hook_civicrm_container().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
  *
- * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
  */
 function remoteevent_civicrm_container(ContainerBuilder $container) {
   $container->addResource(new FileResource(__FILE__));
@@ -392,6 +391,7 @@ function remoteevent_civicrm_permission(&$permissions) {
 
 /**
  * Implements hook_civicrm_alterAPIPermissions().
+ *
  * Set permissions RemoteEvent API
  */
 function remoteevent_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
@@ -496,6 +496,7 @@ function remoteevent_civicrm_custom($op, $groupID, $entityID, &$params): void {
 
 /**
  * Implements hook_civicrm_post().
+ *
  * Monitor Participant objects
  */
 function remoteevent_civicrm_post($op, $objectName, $objectId, &$objectRef) {
@@ -506,6 +507,7 @@ function remoteevent_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
 /**
  * Implements hook_civicrm_pageRun().
+ *
  * Inject session information
  */
 function remoteevent_civicrm_pageRun(&$page) {
@@ -531,6 +533,7 @@ function remoteevent_civicrm_links($op, $objectName, $objectId, &$links, &$mask,
 
 /**
  * Implements hook_civicrm_searchTasks().
+ *
  * Inject our 'Session Registration' task
  */
 function remoteevent_civicrm_searchTasks($objectType, &$tasks) {

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -288,8 +288,6 @@ function remoteevent_civicrm_config(&$config) {
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'registerAdditionalParticipants'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
-
-    // TODO: Process price fields.
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'createOrder'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -291,6 +291,9 @@ function remoteevent_civicrm_config(&$config) {
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,
         ['CRM_Remoteevent_Registration', 'createOrder'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'createPayment'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
 
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -32,8 +32,8 @@ use Civi\RemoteParticipant\Event\UpdateEvent;
 use Civi\RemoteParticipant\Event\ValidateEvent;
 use Civi\RemoteParticipant\EventSubscriber\MailingListSubscriptionSubscriber;
 use Civi\RemoteParticipant\MailingList\DoubleOptInEmailSender;
-use Civi\RemoteParticipant\MailingList\DoubleOptInTokenGenerator;
 use Civi\RemoteParticipant\MailingList\MailingListSubscriptionManager;
+use Civi\RemoteParticipant\MailingList\DoubleOptInTokenGenerator;
 use Civi\RemoteParticipant\RegistrationEventFactory;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
 use CRM_Remoteevent_ExtensionUtil as E;
@@ -205,6 +205,16 @@ function remoteevent_civicrm_config(&$config) {
   );
   $dispatcher->addUniqueListener(
     RegistrationEvent::NAME,
+    ['CRM_Remoteevent_Registration', 'createOrder'],
+    CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION
+  );
+  $dispatcher->addUniqueListener(
+    RegistrationEvent::NAME,
+    ['CRM_Remoteevent_Registration', 'createPayment'],
+    CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION
+  );
+  $dispatcher->addUniqueListener(
+    RegistrationEvent::NAME,
     ['CRM_Remoteevent_EventSessions', 'synchroniseSessions'],
     CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION
   );
@@ -263,43 +273,17 @@ function remoteevent_civicrm_config(&$config) {
     ['CRM_Remoteevent_RemoteEvent', 'listTokens']
   );
 
-    // EVENT REGISTRATION.SUBMIT
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_EventSessions', 'extractSessions'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'identifyRemoteContact'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'createContactXCM'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'verifyContactNotRegistered'], CRM_Remoteevent_Registration::AFTER_CONTACT_IDENTIFICATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'confirmExistingParticipant'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 40);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'determineParticipantStatus'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 20);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'createParticipant'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'registerAdditionalParticipants'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'createOrder'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_Registration', 'createPayment'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
+  // 2) SESSION TOKENS
+  $dispatcher->addUniqueListener(
+    'civi.eventmessages.tokens',
+    ['CRM_Remoteevent_EventSessions', 'addTokens']
+  );
+  $dispatcher->addUniqueListener(
+    'civi.eventmessages.tokenlist',
+    ['CRM_Remoteevent_EventSessions', 'listTokens']
+  );
 
-    $dispatcher->addUniqueListener(
-        RegistrationEvent::NAME,
-        ['CRM_Remoteevent_EventSessions', 'synchroniseSessions'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
-
-  // 2) EVENT LOCATION TOKENS
+  // 3) EVENT LOCATION TOKENS
   $dispatcher->addUniqueListener(
     'civi.eventmessages.tokens',
     ['CRM_Remoteevent_EventLocation', 'addTokens']
@@ -317,7 +301,11 @@ function remoteevent_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_container().
+ * Implements hook_civicrm_container()
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_container/
+ *
+ * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
  */
 function remoteevent_civicrm_container(ContainerBuilder $container) {
   $container->addResource(new FileResource(__FILE__));
@@ -404,6 +392,7 @@ function remoteevent_civicrm_permission(&$permissions) {
 
 /**
  * Implements hook_civicrm_alterAPIPermissions().
+ * Set permissions RemoteEvent API
  */
 function remoteevent_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
   // RemoteEvent entity
@@ -507,6 +496,7 @@ function remoteevent_civicrm_custom($op, $groupID, $entityID, &$params): void {
 
 /**
  * Implements hook_civicrm_post().
+ * Monitor Participant objects
  */
 function remoteevent_civicrm_post($op, $objectName, $objectId, &$objectRef) {
   if (('edit' === $op || 'create' === $op) && 'Participant' === $objectName) {
@@ -516,6 +506,7 @@ function remoteevent_civicrm_post($op, $objectName, $objectId, &$objectRef) {
 
 /**
  * Implements hook_civicrm_pageRun().
+ * Inject session information
  */
 function remoteevent_civicrm_pageRun(&$page) {
   $pageName = $page->getVar('_name');
@@ -540,6 +531,7 @@ function remoteevent_civicrm_links($op, $objectName, $objectId, &$links, &$mask,
 
 /**
  * Implements hook_civicrm_searchTasks().
+ * Inject our 'Session Registration' task
  */
 function remoteevent_civicrm_searchTasks($objectType, &$tasks) {
   // add "Session Registration" task to participant list

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -263,15 +263,37 @@ function remoteevent_civicrm_config(&$config) {
     ['CRM_Remoteevent_RemoteEvent', 'listTokens']
   );
 
-  // 2) SESSION TOKENS
-  $dispatcher->addUniqueListener(
-    'civi.eventmessages.tokens',
-    ['CRM_Remoteevent_EventSessions', 'addTokens']
-  );
-  $dispatcher->addUniqueListener(
-    'civi.eventmessages.tokenlist',
-    ['CRM_Remoteevent_EventSessions', 'listTokens']
-  );
+    // EVENT REGISTRATION.SUBMIT
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_EventSessions', 'extractSessions'], CRM_Remoteevent_Registration::BEFORE_CONTACT_IDENTIFICATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'identifyRemoteContact'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'createContactXCM'], CRM_Remoteevent_Registration::STAGE1_CONTACT_IDENTIFICATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'verifyContactNotRegistered'], CRM_Remoteevent_Registration::AFTER_CONTACT_IDENTIFICATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'confirmExistingParticipant'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 40);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'determineParticipantStatus'], CRM_Remoteevent_Registration::BEFORE_PARTICIPANT_CREATION + 20);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'createParticipant'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'registerAdditionalParticipants'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
+
+    // TODO: Process price fields.
+
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_EventSessions', 'synchroniseSessions'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
 
   // 2) EVENT LOCATION TOKENS
   $dispatcher->addUniqueListener(

--- a/remoteevent.php
+++ b/remoteevent.php
@@ -290,6 +290,9 @@ function remoteevent_civicrm_config(&$config) {
         ['CRM_Remoteevent_Registration', 'registerAdditionalParticipants'], CRM_Remoteevent_Registration::STAGE2_PARTICIPANT_CREATION);
 
     // TODO: Process price fields.
+    $dispatcher->addUniqueListener(
+        RegistrationEvent::NAME,
+        ['CRM_Remoteevent_Registration', 'createOrder'], CRM_Remoteevent_Registration::AFTER_PARTICIPANT_CREATION);
 
     $dispatcher->addUniqueListener(
         RegistrationEvent::NAME,

--- a/tests/phpunit/CRM/Remoteevent/GetFormTest.php
+++ b/tests/phpunit/CRM/Remoteevent/GetFormTest.php
@@ -113,4 +113,16 @@ class CRM_Remoteevent_GetFormTest extends CRM_Remoteevent_TestBase {
 
   }
 
+    public function testWithPriceFields(): void {
+      // TODO: Test for price fields for additional participants.
+      $event = $this->createRemoteEvent([]);
+      $priceFields = $this->addPriceFields((int) $event['id']);
+
+      $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
+        'event_id' => $event['id'],
+      ])['values'];
+
+      $this->assertGetFormPriceFields($fields, $priceFields);
+    }
+
 }

--- a/tests/phpunit/CRM/Remoteevent/GetFormTest.php
+++ b/tests/phpunit/CRM/Remoteevent/GetFormTest.php
@@ -113,16 +113,16 @@ class CRM_Remoteevent_GetFormTest extends CRM_Remoteevent_TestBase {
 
   }
 
-    public function testWithPriceFields(): void {
-      // TODO: Test for price fields for additional participants.
-      $event = $this->createRemoteEvent([]);
-      $priceFields = $this->addPriceFields((int) $event['id']);
+  public function testWithPriceFields(): void {
+    // TODO: Test for price fields for additional participants.
+    $event = $this->createRemoteEvent([]);
+    $priceFields = $this->addPriceFields((int) $event['id']);
 
-      $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
-        'event_id' => $event['id'],
-      ])['values'];
+    $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
+      'event_id' => $event['id'],
+    ])['values'];
 
-      $this->assertGetFormPriceFields($fields, $priceFields);
-    }
+    $this->assertGetFormPriceFields($fields, $priceFields);
+  }
 
 }

--- a/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
@@ -157,77 +157,77 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase {
     ], 'Value too long');
   }
 
-    public function testRegistrationWithPriceFields(): void {
-      $event = $this->createRemoteEvent();
-      $priceFields = $this->addPriceFields((int) $event['id']);
+  public function testRegistrationWithPriceFields(): void {
+    $event = $this->createRemoteEvent();
+    $priceFields = $this->addPriceFields((int) $event['id']);
 
-      $contact = $this->createContact();
-      $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
-        'event_id' => $event['id'],
-      ])['values'];
-      $priceFieldOneValue = isset($fields['price_' . $priceFields[0]['name']]['options'])
+    $contact = $this->createContact();
+    $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
+      'event_id' => $event['id'],
+    ])['values'];
+    $priceFieldOneValue = isset($fields['price_' . $priceFields[0]['name']]['options'])
         // First option
         ? key($fields['price_' . $priceFields[0]['name']]['options'])
         // Quantity of 2
         : 2;
-      $priceFieldTwoValue = isset($fields['price_' . $priceFields[1]['name']]['options'])
+    $priceFieldTwoValue = isset($fields['price_' . $priceFields[1]['name']]['options'])
         // First option
         ? key($fields['price_' . $priceFields[1]['name']]['options'])
         // Quantity of 2
         : 2;
 
-      $registration = $this->registerRemote($event['id'], [
-        'first_name' => $contact['first_name'],
-        'last_name'  => $contact['last_name'],
-        'email' => $contact['email'],
-        'price_' . $priceFields[0]['name'] => $priceFieldOneValue,
-        'price_' . $priceFields[1]['name'] => $priceFieldTwoValue,
-        'payment_method' => 'pay_later',
-      ]);
+    $registration = $this->registerRemote($event['id'], [
+      'first_name' => $contact['first_name'],
+      'last_name'  => $contact['last_name'],
+      'email' => $contact['email'],
+      'price_' . $priceFields[0]['name'] => $priceFieldOneValue,
+      'price_' . $priceFields[1]['name'] => $priceFieldTwoValue,
+      'payment_method' => 'pay_later',
+    ]);
 
-      $this->assertAPISuccess($registration, 'Registration with price fields failed');
+    $this->assertAPISuccess($registration, 'Registration with price fields failed');
 
-      $lineItems = \Civi\Api4\LineItem::get(TRUE)
-        ->addSelect('participant.contact_id', 'price_field_id', 'price_field_value_id', 'qty')
-        ->addJoin('Participant AS participant', 'INNER', ['participant.id', '=', 'entity_id'])
-        ->addWhere('entity_table', '=', 'civicrm_participant')
-        ->addWhere('price_field_id', 'IN', array_column($priceFields, 'id'))
-        ->addWhere('participant.id', '=', $registration['participant_id'])
-        ->execute()
-        ->getArrayCopy();
+    $lineItems = \Civi\Api4\LineItem::get(TRUE)
+      ->addSelect('participant.contact_id', 'price_field_id', 'price_field_value_id', 'qty')
+      ->addJoin('Participant AS participant', 'INNER', ['participant.id', '=', 'entity_id'])
+      ->addWhere('entity_table', '=', 'civicrm_participant')
+      ->addWhere('price_field_id', 'IN', array_column($priceFields, 'id'))
+      ->addWhere('participant.id', '=', $registration['participant_id'])
+      ->execute()
+      ->getArrayCopy();
 
-      // Assert number of line items.
-      self::assertCount(2, $lineItems, sprintf("Expected 2 line items but found %d", count($lineItems)));
+    // Assert number of line items.
+    self::assertCount(2, $lineItems, sprintf('Expected 2 line items but found %d', count($lineItems)));
 
-      // Assert line item for the option price field.
-      self::assertArraySubset(
-        [
-          'price_field_id' => $priceFields[0]['id'],
-          'price_field_value_id' => $priceFieldOneValue,
-        ],
-        $lineItems[0],
-        FALSE,
-        sprintf(
-          "Expected line item with price field value ID %d for price field ID %d",
-          $priceFields[0]['id'],
-          $priceFieldOneValue
-        )
-      );
+    // Assert line item for the option price field.
+    self::assertArraySubset(
+    [
+      'price_field_id' => $priceFields[0]['id'],
+      'price_field_value_id' => $priceFieldOneValue,
+    ],
+    $lineItems[0],
+    FALSE,
+    sprintf(
+      'Expected line item with price field value ID %d for price field ID %d',
+      $priceFields[0]['id'],
+      $priceFieldOneValue
+    )
+    );
 
-      // Assert line item for the amount price field.
-      self::assertArraySubset(
-        [
-          'price_field_id' => $priceFields[1]['id'],
-          'qty' => $priceFieldTwoValue,
-        ],
-        $lineItems[1],
-        FALSE,
-        sprintf(
-          "Expected line item with price field value ID %d for price field ID %d",
-          $priceFields[1]['id'],
-          $priceFieldTwoValue
-        )
-      );
-    }
+    // Assert line item for the amount price field.
+    self::assertArraySubset(
+    [
+      'price_field_id' => $priceFields[1]['id'],
+      'qty' => $priceFieldTwoValue,
+    ],
+    $lineItems[1],
+    FALSE,
+    sprintf(
+      'Expected line item with price field value ID %d for price field ID %d',
+      $priceFields[1]['id'],
+      $priceFieldTwoValue
+    )
+    );
+  }
 
 }

--- a/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
@@ -197,10 +197,10 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase {
         ->getArrayCopy();
 
       // Assert number of line items.
-      $this->assertCount(2, $lineItems, sprintf("Expected 2 line items but found %d", count($lineItems)));
+      self::assertCount(2, $lineItems, sprintf("Expected 2 line items but found %d", count($lineItems)));
 
       // Assert line item for the option price field.
-      $this->assertArraySubset(
+      self::assertArraySubset(
         [
           'price_field_id' => $priceFields[0]['id'],
           'price_field_value_id' => $priceFieldOneValue,
@@ -215,7 +215,7 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase {
       );
 
       // Assert line item for the amount price field.
-      $this->assertArraySubset(
+      self::assertArraySubset(
         [
           'price_field_id' => $priceFields[1]['id'],
           'qty' => $priceFieldTwoValue,

--- a/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
@@ -182,6 +182,7 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase {
         'email' => $contact['email'],
         'price_' . $priceFields[0]['name'] => $priceFieldOneValue,
         'price_' . $priceFields[1]['name'] => $priceFieldTwoValue,
+        'payment_method' => 'pay_later',
       ]);
 
       $this->assertAPISuccess($registration, 'Registration with price fields failed');

--- a/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
+++ b/tests/phpunit/CRM/Remoteevent/RegistrationTest.php
@@ -157,4 +157,76 @@ class CRM_Remoteevent_RegistrationTest extends CRM_Remoteevent_TestBase {
     ], 'Value too long');
   }
 
+    public function testRegistrationWithPriceFields(): void {
+      $event = $this->createRemoteEvent();
+      $priceFields = $this->addPriceFields((int) $event['id']);
+
+      $contact = $this->createContact();
+      $fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
+        'event_id' => $event['id'],
+      ])['values'];
+      $priceFieldOneValue = isset($fields['price_' . $priceFields[0]['name']]['options'])
+        // First option
+        ? key($fields['price_' . $priceFields[0]['name']]['options'])
+        // Quantity of 2
+        : 2;
+      $priceFieldTwoValue = isset($fields['price_' . $priceFields[1]['name']]['options'])
+        // First option
+        ? key($fields['price_' . $priceFields[1]['name']]['options'])
+        // Quantity of 2
+        : 2;
+
+      $registration = $this->registerRemote($event['id'], [
+        'first_name' => $contact['first_name'],
+        'last_name'  => $contact['last_name'],
+        'email' => $contact['email'],
+        'price_' . $priceFields[0]['name'] => $priceFieldOneValue,
+        'price_' . $priceFields[1]['name'] => $priceFieldTwoValue,
+      ]);
+
+      $this->assertAPISuccess($registration, 'Registration with price fields failed');
+
+      $lineItems = \Civi\Api4\LineItem::get(TRUE)
+        ->addSelect('participant.contact_id', 'price_field_id', 'price_field_value_id', 'qty')
+        ->addJoin('Participant AS participant', 'INNER', ['participant.id', '=', 'entity_id'])
+        ->addWhere('entity_table', '=', 'civicrm_participant')
+        ->addWhere('price_field_id', 'IN', array_column($priceFields, 'id'))
+        ->addWhere('participant.id', '=', $registration['participant_id'])
+        ->execute()
+        ->getArrayCopy();
+
+      // Assert number of line items.
+      $this->assertCount(2, $lineItems, sprintf("Expected 2 line items but found %d", count($lineItems)));
+
+      // Assert line item for the option price field.
+      $this->assertArraySubset(
+        [
+          'price_field_id' => $priceFields[0]['id'],
+          'price_field_value_id' => $priceFieldOneValue,
+        ],
+        $lineItems[0],
+        FALSE,
+        sprintf(
+          "Expected line item with price field value ID %d for price field ID %d",
+          $priceFields[0]['id'],
+          $priceFieldOneValue
+        )
+      );
+
+      // Assert line item for the amount price field.
+      $this->assertArraySubset(
+        [
+          'price_field_id' => $priceFields[1]['id'],
+          'qty' => $priceFieldTwoValue,
+        ],
+        $lineItems[1],
+        FALSE,
+        sprintf(
+          "Expected line item with price field value ID %d for price field ID %d",
+          $priceFields[1]['id'],
+          $priceFieldTwoValue
+        )
+      );
+    }
+
 }

--- a/tests/phpunit/CRM/Remoteevent/TestBase.php
+++ b/tests/phpunit/CRM/Remoteevent/TestBase.php
@@ -62,9 +62,9 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     $profile = CRM_Xcm_Configuration::getConfigProfile('default');
 
     // jumble the participant status labels so we're sure we only using the names
-    CRM_Core_DAO::executeQuery("UPDATE civicrm_participant_status_type SET label = MD5(name);");
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_participant_status_type SET label = MD5(name);');
 
-    //Civi::settings()->set('remote_event_get_performance_enhancement', true);
+    /** Civi::settings()->set('remote_event_get_performance_enhancement', true); */
   }
 
   protected function tearDown(): void {
@@ -74,7 +74,7 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     parent::tearDown();
   }
 
-    /**
+  /**
    * Create a new remote event. All of the
    *  vital fields will have default values, that can be overwritten by
    *  the array passed
@@ -103,7 +103,8 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     foreach ($event_details as $key => $value) {
       if (NULL === $value) {
         unset($event_data[$key]);
-      } else {
+      }
+      else {
         $event_data[$key] = $value;
       }
     }
@@ -119,7 +120,8 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     if ($use_remote_api) {
       $result = $this->traitCallAPISuccess('RemoteEvent', 'spawn', $event_data);
       $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
-    } else {
+    }
+    else {
       $result = $this->traitCallAPISuccess('Event', 'create', $event_data);
       $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
       CRM_Remoteevent_CustomData::labelCustomFields($event);
@@ -162,86 +164,86 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
    * @phpstan-return list<array<string, mixed>>
    *   A list of price fields added to the event.
    */
-    public function addPriceFields(int $eventId): array {
-      $priceFields = [];
+  public function addPriceFields(int $eventId): array {
+    $priceFields = [];
 
-      $priceSet = \Civi\Api4\PriceSet::create(TRUE)
-        ->addValue('title', 'Test Price Set')
-        ->addValue('extends:name', ['CiviEvent'])
-        ->addValue('name', 'test_price_set')
-        ->execute()
-        ->single();
+    $priceSet = \Civi\Api4\PriceSet::create(TRUE)
+      ->addValue('title', 'Test Price Set')
+      ->addValue('extends:name', ['CiviEvent'])
+      ->addValue('name', 'test_price_set')
+      ->execute()
+      ->single();
 
-      $optionsPriceField = \Civi\Api4\PriceField::create(TRUE)
-        ->addValue('price_set_id', $priceSet['id'])
-        ->addValue('name', 'test_price_options_field')
-        ->addValue('label', 'Test Price Options Field')
-        ->addValue('html_type', 'Select')
-        ->execute()
-        ->single();
-      $priceFields[] = $optionsPriceField;
-      $priceFieldValueRegular = \Civi\Api4\PriceFieldValue::create(TRUE)
-        ->addValue('label', 'Regular Fee')
-        ->addValue('amount', 20)
+    $optionsPriceField = \Civi\Api4\PriceField::create(TRUE)
+      ->addValue('price_set_id', $priceSet['id'])
+      ->addValue('name', 'test_price_options_field')
+      ->addValue('label', 'Test Price Options Field')
+      ->addValue('html_type', 'Select')
+      ->execute()
+      ->single();
+    $priceFields[] = $optionsPriceField;
+    $priceFieldValueRegular = \Civi\Api4\PriceFieldValue::create(TRUE)
+      ->addValue('label', 'Regular Fee')
+      ->addValue('amount', 20)
         // price_field_id.name does not seem to be accepted, so use the actual ID.
-        ->addValue('price_field_id', $optionsPriceField['id'])
-        ->addValue('financial_type_id:name', 'Event Fee')
-        ->execute();
-      $priceFieldValueDiscount = \Civi\Api4\PriceFieldValue::create(TRUE)
-        ->addValue('label', 'Discount Fee')
-        ->addValue('amount', 10)
-        ->addValue('price_field_id', $optionsPriceField['id'])
-        ->addValue('financial_type_id:name', 'Event Fee')
-        ->execute();
+      ->addValue('price_field_id', $optionsPriceField['id'])
+      ->addValue('financial_type_id:name', 'Event Fee')
+      ->execute();
+    $priceFieldValueDiscount = \Civi\Api4\PriceFieldValue::create(TRUE)
+      ->addValue('label', 'Discount Fee')
+      ->addValue('amount', 10)
+      ->addValue('price_field_id', $optionsPriceField['id'])
+      ->addValue('financial_type_id:name', 'Event Fee')
+      ->execute();
 
-      $amountPriceField = \Civi\Api4\PriceField::create(TRUE)
-        ->addValue('price_set_id', $priceSet['id'])
-        ->addValue('name', 'test_price_amount_field')
-        ->addValue('label', 'Test Price Amount Field')
-        ->addValue('html_type', 'Text')
-        ->addValue('is_enter_qty', TRUE)
-        ->execute()
-        ->single();
-      $priceFieldValueAmount = \Civi\Api4\PriceFieldValue::create(TRUE)
-        ->addValue('label', 'Amount of Stuff')
-        ->addValue('amount', 25)
-        ->addValue('price_field_id', $amountPriceField['id'])
-        ->addValue('financial_type_id:name', 'Event Fee')
-        ->execute();
-      $priceFields[] = $amountPriceField;
+    $amountPriceField = \Civi\Api4\PriceField::create(TRUE)
+      ->addValue('price_set_id', $priceSet['id'])
+      ->addValue('name', 'test_price_amount_field')
+      ->addValue('label', 'Test Price Amount Field')
+      ->addValue('html_type', 'Text')
+      ->addValue('is_enter_qty', TRUE)
+      ->execute()
+      ->single();
+    $priceFieldValueAmount = \Civi\Api4\PriceFieldValue::create(TRUE)
+      ->addValue('label', 'Amount of Stuff')
+      ->addValue('amount', 25)
+      ->addValue('price_field_id', $amountPriceField['id'])
+      ->addValue('financial_type_id:name', 'Event Fee')
+      ->execute();
+    $priceFields[] = $amountPriceField;
 
-      // Make the event monetary and assign a financial type.
-      \Civi\Api4\Event::update(TRUE)
-        ->addValue('is_monetary', TRUE)
-        ->addValue('financial_type_id:name', 'Event Fee')
-        ->addValue('fee_label', 'Test Fee Label')
-        ->addValue('currency', 'EUR')
-        ->addWhere('id', '=', $eventId)
-        ->execute();
+    // Make the event monetary and assign a financial type.
+    \Civi\Api4\Event::update(TRUE)
+      ->addValue('is_monetary', TRUE)
+      ->addValue('financial_type_id:name', 'Event Fee')
+      ->addValue('fee_label', 'Test Fee Label')
+      ->addValue('currency', 'EUR')
+      ->addWhere('id', '=', $eventId)
+      ->execute();
 
-      // Assign the price set to the event.
-      \Civi\Api4\PriceSetEntity::create(TRUE)
-        ->addValue('entity_table', 'civicrm_event')
-        ->addValue('entity_id', $eventId)
-        ->addValue('price_set_id', $priceSet['id'])
-        ->execute();
+    // Assign the price set to the event.
+    \Civi\Api4\PriceSetEntity::create(TRUE)
+      ->addValue('entity_table', 'civicrm_event')
+      ->addValue('entity_id', $eventId)
+      ->addValue('price_set_id', $priceSet['id'])
+      ->execute();
 
-      return $priceFields;
-    }
+    return $priceFields;
+  }
 
-    /**
-     * Create a new session
-     *
-     * @params
-     * @param array $session_details
-     *   overrides the default values
-     *
-     * @return array
-     *   contact data
-     */
+  /**
+   * Create a new session
+   *
+   * @params
+   * @param array $session_details
+   *   overrides the default values
+   *
+   * @return array
+   *   contact data
+   */
   public function createEventSession($event_id, $session_details = []) {
-        // prepare event
-        $session_data = [
+    // prepare event
+    $session_data = [
       'event_id' => $event_id,
       'title' => $this->randomString(50),
       'is_active' => 1,
@@ -251,16 +253,16 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
       'type_id' => 1,
       'description' => $this->randomString(50),
       'max_participants' => NULL,
-        ];
-        foreach ($session_details as $key => $value) {
-            $session_data[$key] = $value;
-        }
-
-        // create contact
-        $result = $this->traitCallAPISuccess('Session', 'create', $session_data);
-        $session = $this->traitCallAPISuccess('Session', 'getsingle', ['id' => $result['id']]);
-        return $session;
+    ];
+    foreach ($session_details as $key => $value) {
+      $session_data[$key] = $value;
     }
+
+    // create contact
+    $result = $this->traitCallAPISuccess('Session', 'create', $session_data);
+    $session = $this->traitCallAPISuccess('Session', 'getsingle', ['id' => $result['id']]);
+    return $session;
+  }
 
   /**
    * Create a number of events with the same setup,
@@ -312,14 +314,16 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
         "API Call {$entity}.{$action} doesn't return 'status_messages'"
       );
       $status_messages = $result['status_messages'];
-    } catch (CRM_Core_Exception $ex) {
+    }
+    catch (CRM_Core_Exception $ex) {
       $result = [
         'is_error' => 1,
         'error_message' => $ex->getMessage(),
       ];
       if (isset($ex->getErrorData()['status_messages'])) {
         $status_messages = $ex->getErrorData()['status_messages'];
-      } else {
+      }
+      else {
         $status_messages = [];
       }
     }
@@ -437,7 +441,7 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
       // simply try again (recursively). Is this dangerous? Yes, but veeeery unlikely... :)
       return $this->randomString($length);
     }
-    // mark as 'generated':
+    /** mark as 'generated' */
     $generated_strings[$candidate] = 1;
     return $candidate;
   }
@@ -457,7 +461,8 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     $profiles = Civi::settings()->get('xcm_config_profiles');
     if (NULL !== $profile_data_override && [] !== $profile_data_override) {
       $profiles[$profile_name] = $profile_data_override;
-    } else {
+    }
+    else {
       $profileJson = file_get_contents(E::path('tests/resources/xcm_profile_testing.json'));
       if (FALSE !== $profileJson) {
         $profiles[$profile_name] = json_decode(
@@ -733,7 +738,8 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     static $last_timestamp = NULL;
     if (NULL === $last_timestamp) {
       $last_timestamp = strtotime('now + 1 hour');
-    } else {
+    }
+    else {
       $last_timestamp = strtotime('+5 minutes', $last_timestamp);
     }
     return date('YmdHis', $last_timestamp);
@@ -775,4 +781,5 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     }
     return $result;
   }
+
 }

--- a/tests/phpunit/CRM/Remoteevent/TestBase.php
+++ b/tests/phpunit/CRM/Remoteevent/TestBase.php
@@ -696,7 +696,7 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
   public function assertGetFormPriceFields(&$fields, $priceFields): void {
     foreach ($priceFields as $priceField) {
       $formFieldName = 'price_' . $priceField['name'];
-      $this->assertArrayHasKey(
+      self::assertArrayHasKey(
         $formFieldName,
         $fields,
         sprintf("RemoteContact.get_form should contain '%s' field", $formFieldName)

--- a/tests/phpunit/CRM/Remoteevent/TestBase.php
+++ b/tests/phpunit/CRM/Remoteevent/TestBase.php
@@ -434,9 +434,110 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
       $count = mt_rand(1, count($array) - 1);
     }
 
-    $random_keys = array_rand($array, $count);
-    if (!is_array($random_keys)) {
-      $random_keys = [$random_keys];
+  /**
+   * @phpstan-return list<array<string, mixed>>
+   *   A list of price fields added to the event.
+   */
+    public function addPriceFields(int $eventId): array {
+      $priceFields = [];
+
+      $priceSet = \Civi\Api4\PriceSet::create(TRUE)
+        ->addValue('title', 'Test Price Set')
+        ->addValue('extends:name', ['CiviEvent'])
+        ->addValue('name', 'test_price_set')
+        ->execute()
+        ->single();
+
+      $optionsPriceField = \Civi\Api4\PriceField::create(TRUE)
+        ->addValue('price_set_id', $priceSet['id'])
+        ->addValue('name', 'test_price_options_field')
+        ->addValue('label', 'Test Price Options Field')
+        ->addValue('html_type', 'Select')
+        ->execute()
+        ->single();
+      $priceFields[] = $optionsPriceField;
+      $priceFieldValueRegular = \Civi\Api4\PriceFieldValue::create(TRUE)
+        ->addValue('label', 'Regular Fee')
+        ->addValue('amount', 20)
+        // price_field_id.name does not seem to be accepted, so use the actual ID.
+        ->addValue('price_field_id', $optionsPriceField['id'])
+        ->addValue('financial_type_id:name', 'Event Fee')
+        ->execute();
+      $priceFieldValueDiscount = \Civi\Api4\PriceFieldValue::create(TRUE)
+        ->addValue('label', 'Discount Fee')
+        ->addValue('amount', 10)
+        ->addValue('price_field_id', $optionsPriceField['id'])
+        ->addValue('financial_type_id:name', 'Event Fee')
+        ->execute();
+
+      $amountPriceField = \Civi\Api4\PriceField::create(TRUE)
+        ->addValue('price_set_id', $priceSet['id'])
+        ->addValue('name', 'test_price_amount_field')
+        ->addValue('label', 'Test Price Amount Field')
+        ->addValue('html_type', 'Text')
+        ->addValue('is_enter_qty', TRUE)
+        ->execute()
+        ->single();
+      $priceFieldValueAmount = \Civi\Api4\PriceFieldValue::create(TRUE)
+        ->addValue('label', 'Amount of Stuff')
+        ->addValue('amount', 25)
+        ->addValue('price_field_id', $amountPriceField['id'])
+        ->addValue('financial_type_id:name', 'Event Fee')
+        ->execute();
+      $priceFields[] = $amountPriceField;
+
+      // Make the event monetary and assign a financial type.
+      \Civi\Api4\Event::update(TRUE)
+        ->addValue('is_monetary', TRUE)
+        ->addValue('financial_type_id:name', 'Event Fee')
+        ->addValue('fee_label', 'Test Fee Label')
+        ->addValue('currency', 'EUR')
+        ->addWhere('id', '=', $eventId)
+        ->execute();
+
+      // Assign the price set to the event.
+      \Civi\Api4\PriceSetEntity::create(TRUE)
+        ->addValue('entity_table', 'civicrm_event')
+        ->addValue('entity_id', $eventId)
+        ->addValue('price_set_id', $priceSet['id'])
+        ->execute();
+
+      return $priceFields;
+    }
+
+    /**
+     * Create a new session
+     *
+     * @params
+     * @param array $session_details
+     *   overrides the default values
+     *
+     * @return array
+     *  contact data
+     */
+    public function createEventSession($event_id, $session_details = [])
+    {
+        // prepare event
+        $session_data = [
+            'event_id'         => $event_id,
+            'title'            => $this->randomString(50),
+            'is_active'        => 1,
+            'start_date'       => $this->getUniqueDateTime(),
+            'end_date'         => $this->getUniqueDateTime(),
+            //'slot_id'        => '',
+            'category_id'      => 1,
+            'type_id'          => 1,
+            'description'      => $this->randomString(50),
+            'max_participants' => null,
+        ];
+        foreach ($session_details as $key => $value) {
+            $session_data[$key] = $value;
+        }
+
+        // create contact
+        $result = $this->traitCallAPISuccess('Session', 'create', $session_data);
+        $session = $this->traitCallAPISuccess('Session', 'getsingle', ['id' => $result['id']]);
+        return $session;
     }
 
     // create result array
@@ -701,4 +802,134 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     parent::tearDown();
   }
 
+        $this->assertArrayHasKey($status_name, $participant_statuses, "Participant status '{$status_name} doesn't exist.");
+        return $participant_statuses[$status_name];
+    }
+
+    /**
+     * Verify that the participant object has the right status
+     *
+     * @param integer $participant_id
+     *   the participant ID
+     * @param integer|string $participant_status
+     *   the expected participant status
+     * @param string $failure_msg
+     *   message to log in case of failure
+     */
+    public function assertParticipantStatus($participant_id, $participant_status, $failure_msg)
+    {
+        $participant = $this->traitCallAPISuccess('Participant', 'get', ['id' => $participant_id]);
+        $this->assertGreaterThan(0, $participant['count'], $failure_msg . " (doesn't exist)");
+        $this->assertLessThan(2, $participant['count'], $failure_msg . " (ambiguous)");
+        $participant = reset($participant['values']);
+
+        $this->assertEquals($this->getParticipantStatusId($participant_status, true), $participant['participant_status_id'], $failure_msg);
+    }
+
+    /**
+     * Verify that the RemoteContact.get_form standard 'fields' are there
+     *
+     * @param array $fields
+     *   the fields reported by the get_form
+     * @param boolean $strip_fields
+     *   if true, the standard fields are removed from the $fields array
+     */
+    public function assertGetFormStandardFields(&$fields, $strip_fields = false)
+    {
+        // todo: check more?
+        $this->assertArrayHasKey('event_id', $fields, "RemoteContact.get_form should contain 'event_id' field");
+        $field_spec = $fields['event_id'];
+        $this->assertArrayHasKey('profile', $fields, "RemoteContact.get_form should contain 'profile' field");
+        $field_spec = $fields['profile'];
+        $this->assertArrayHasKey('remote_contact_id', $fields, "RemoteContact.get_form should contain 'remote_contact_id' field");
+        $field_spec = $fields['remote_contact_id'];
+
+        if ($strip_fields) {
+            unset($fields['event_id']);
+            unset($fields['profile']);
+            unset($fields['remote_contact_id']);
+        }
+    }
+
+    public function assertGetFormPriceFields(&$fields, $priceFields): void {
+      foreach ($priceFields as $priceField) {
+        $formFieldName = 'price_' . $priceField['name'];
+        $this->assertArrayHasKey(
+          $formFieldName,
+          $fields,
+          sprintf("RemoteContact.get_form should contain '%s' field", $formFieldName)
+        );
+      }
+    }
+
+    /**
+     * Create a new, unique campaign
+     */
+    public function getCampaign() {
+        $campaign_name = $this->randomString();
+        $campaign = $this->traitCallAPISuccess('Campaign', 'create', [
+            'name' => $campaign_name,
+            'title' => $campaign_name,
+            'campaign_type_id' => 1,
+            'status_id' => 1,
+        ]);
+        return $this->traitCallAPISuccess('Campaign', 'getsingle', ['id' => $campaign['id']]);
+    }
+
+    /**
+     * Get a (within this test) unique
+     *  timestamp. It starts with now+1h and
+     *  increments in 5 minute interval
+     *
+     * @return string timestamp
+     */
+    public function getUniqueDateTime()
+    {
+        static $last_timestamp = null;
+        if ($last_timestamp === null) {
+            $last_timestamp = strtotime('now + 1 hour');
+        } else {
+            $last_timestamp = strtotime('+5 minutes', $last_timestamp);
+        }
+        return date('YmdHis', $last_timestamp);
+    }
+
+
+    /**
+     * Create an associative array from a list of fields specs in the form of
+     * [
+     *   [
+     *      'name'        => 'some field name',
+     *      'type'        => CRM_Utils_Type::T_STRING,
+     *      'value'       => 'some value',
+     *      'title'       => 'some title',
+     *      'localizable' => 0,
+     *   ],
+     *    ...
+     * ]
+     *
+     * @param array $field_array
+     *    the outer array
+     * @param string $key_field
+     *    the inner field to be used as key
+     * @param string $value_field
+     *    the inner field to be used as value
+     *
+     * @return array
+     *    the extracted associative array
+     */
+    public function mapFieldArray($field_array, $key_field = 'name', $value_field = 'value')
+    {
+        $result = [];
+        foreach ($field_array as $field_spec) {
+            if (!isset($field_spec[$key_field])) {
+                $this->fail("Field array doesn't have key field '{$key_field}'");
+            }
+            if (!isset($field_spec[$value_field])) {
+                $this->fail("Field array doesn't have value field '{$value_field}'");
+            }
+            $result[$field_spec[$key_field]] = $field_spec[$value_field];
+        }
+        return $result;
+    }
 }

--- a/tests/phpunit/CRM/Remoteevent/TestBase.php
+++ b/tests/phpunit/CRM/Remoteevent/TestBase.php
@@ -19,6 +19,7 @@ use Civi\Test\Api3TestTrait;
 use Civi\Test\HeadlessInterface;
 use Civi\Core\HookInterface;
 use Civi\Test\TransactionalInterface;
+
 use CRM_Remoteevent_ExtensionUtil as E;
 
 /**
@@ -52,6 +53,81 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
       ->apply();
   }
 
+  public function setUp(): void {
+    parent::setUp();
+    CRM_Xcm_Configuration::flushProfileCache();
+    $this->transaction = new CRM_Core_Transaction();
+    $this->setUpXCMProfile('default');
+
+    $profile = CRM_Xcm_Configuration::getConfigProfile('default');
+
+    // jumble the participant status labels so we're sure we only using the names
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_participant_status_type SET label = MD5(name);");
+
+    //Civi::settings()->set('remote_event_get_performance_enhancement', true);
+  }
+
+  protected function tearDown(): void {
+    $this->transaction->rollback();
+    $this->transaction = NULL;
+    CRM_Remoteevent_CustomData::flushCashes();
+    parent::tearDown();
+  }
+
+    /**
+   * Create a new remote event. All of the
+   *  vital fields will have default values, that can be overwritten by
+   *  the array passed
+   *
+   * @param array $event_details
+   *   list of event parameters
+   *
+   * @param boolean $use_remote_api
+   *   use the exposed RemoteEvent.create API instead of the internal (Event.create)
+   */
+  public function createRemoteEvent($event_details = [], $use_remote_api = FALSE) {
+    // prepare event
+    $event_data = [
+      'title' => 'Event ' . microtime(),
+      'event_type_id' => 1,
+      'start_date' => date('Y-m-d', strtotime('tomorrow')),
+      'default_role_id' => 1,
+      'is_active' => 1,
+      'event_remote_registration.remote_registration_enabled' => 1,
+      'event_remote_registration.remote_disable_civicrm_registration' => 1,
+      'event_remote_registration.remote_registration_default_profile' => 'Standard1',
+      'event_remote_registration.remote_registration_profiles' => ['Standard1'],
+      'event_remote_registration.remote_registration_default_update_profile' => 'Standard1',
+      'event_remote_registration.remote_registration_update_profiles' => ['Standard1'],
+    ];
+    foreach ($event_details as $key => $value) {
+      if (NULL === $value) {
+        unset($event_data[$key]);
+      } else {
+        $event_data[$key] = $value;
+      }
+    }
+    // sanity check: default profile should be enabled
+    $default_profile = $event_data['event_remote_registration.remote_registration_default_profile'];
+    if (!in_array($default_profile, $event_data['event_remote_registration.remote_registration_profiles'], TRUE)) {
+      $event_data['event_remote_registration.remote_registration_profiles'][] = $default_profile;
+    }
+    // resolve custom fields
+    CRM_Remoteevent_CustomData::resolveCustomFields($event_data);
+
+    // create event and reload
+    if ($use_remote_api) {
+      $result = $this->traitCallAPISuccess('RemoteEvent', 'spawn', $event_data);
+      $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
+    } else {
+      $result = $this->traitCallAPISuccess('Event', 'create', $event_data);
+      $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
+      CRM_Remoteevent_CustomData::labelCustomFields($event);
+    }
+
+    return $event;
+  }
+
   /**
    * Create a new remote event TEMPLATE
    *
@@ -81,358 +157,6 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     CRM_Remoteevent_CustomData::labelCustomFields($event_template);
     return $event_template;
   }
-
-  /**
-   * Create a new remote event. All of the
-   *  vital fields will have default values, that can be overwritten by
-   *  the array passed
-   *
-   * @param array $event_details
-   *   list of event parameters
-   *
-   * @param boolean $use_remote_api
-   *   use the exposed RemoteEvent.create API instead of the internal (Event.create)
-   */
-  public function createRemoteEvent($event_details = [], $use_remote_api = FALSE) {
-    // prepare event
-    $event_data = [
-      'title' => 'Event ' . microtime(),
-      'event_type_id' => 1,
-      'start_date' => date('Y-m-d', strtotime('tomorrow')),
-      'default_role_id' => 1,
-      'is_active' => 1,
-      'event_remote_registration.remote_registration_enabled' => 1,
-      'event_remote_registration.remote_disable_civicrm_registration' => 1,
-      'event_remote_registration.remote_registration_default_profile' => 'Standard1',
-      'event_remote_registration.remote_registration_profiles' => ['Standard1'],
-      'event_remote_registration.remote_registration_default_update_profile' => 'Standard1',
-      'event_remote_registration.remote_registration_update_profiles' => ['Standard1'],
-    ];
-    foreach ($event_details as $key => $value) {
-      if ($value === NULL) {
-        unset($event_data[$key]);
-      }
-      else {
-        $event_data[$key] = $value;
-      }
-    }
-    // sanity check: default profile should be enabled
-    $default_profile = $event_data['event_remote_registration.remote_registration_default_profile'];
-    if (!in_array($default_profile, $event_data['event_remote_registration.remote_registration_profiles'], TRUE)) {
-      $event_data['event_remote_registration.remote_registration_profiles'][] = $default_profile;
-    }
-    // resolve custom fields
-    CRM_Remoteevent_CustomData::resolveCustomFields($event_data);
-
-    // create event and reload
-    if ($use_remote_api) {
-      $result = $this->traitCallAPISuccess('RemoteEvent', 'spawn', $event_data);
-      $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
-    }
-    else {
-      $result = $this->traitCallAPISuccess('Event', 'create', $event_data);
-      $event = $this->traitCallAPISuccess('RemoteEvent', 'getsingle', ['id' => $result['id']]);
-      CRM_Remoteevent_CustomData::labelCustomFields($event);
-    }
-
-    return $event;
-  }
-
-  /**
-   * Create a new session
-   *
-   * @params
-   * @param array $session_details
-   *   overrides the default values
-   *
-   * @return array
-   *   contact data
-   */
-  public function createEventSession($event_id, $session_details = []) {
-    // prepare event
-    $session_data = [
-      'event_id' => $event_id,
-      'title' => $this->randomString(50),
-      'is_active' => 1,
-      'start_date' => $this->getUniqueDateTime(),
-      'end_date' => $this->getUniqueDateTime(),
-      'category_id' => 1,
-      'type_id' => 1,
-      'description' => $this->randomString(50),
-      'max_participants' => NULL,
-    ];
-    foreach ($session_details as $key => $value) {
-      $session_data[$key] = $value;
-    }
-
-    // create contact
-    $result = $this->traitCallAPISuccess('Session', 'create', $session_data);
-    $session = $this->traitCallAPISuccess('Session', 'getsingle', ['id' => $result['id']]);
-    return $session;
-  }
-
-  /**
-   * Generate a random string, and make sure we don't collide
-   *
-   * @param int $length
-   *   length of the string
-   *
-   * @return string
-   *   random string
-   */
-  public function randomString($length = 32) {
-    static $generated_strings = [];
-    $candidate = substr(sha1(random_bytes(32)), 0, $length);
-    if (isset($generated_strings[$candidate])) {
-      // simply try again (recursively). Is this dangerous? Yes, but veeeery unlikely... :)
-      return $this->randomString($length);
-    }
-    // Mark generated:
-    $generated_strings[$candidate] = 1;
-    return $candidate;
-  }
-
-  /**
-   * Get a (within this test) unique
-   *  timestamp. It starts with now+1h and
-   *  increments in 5 minute interval
-   *
-   * @return string timestamp
-   */
-  public function getUniqueDateTime() {
-    static $last_timestamp = NULL;
-    if ($last_timestamp === NULL) {
-      $last_timestamp = strtotime('now + 1 hour');
-    }
-    else {
-      $last_timestamp = strtotime('+5 minutes', $last_timestamp);
-    }
-    return date('YmdHis', $last_timestamp);
-  }
-
-  /**
-   * Create a number of events with the same setup,
-   *   using the createRemoteEvent function
-   *
-   * @param integer $count
-   * @param array $event_details
-   *
-   * @return array [event_id => $event_data]
-   */
-  public function createRemoteEvents($count, $event_details = []) {
-    $result = [];
-    for ($i = 0; $i < $count; $i++) {
-      $event = $this->createRemoteEvent($event_details);
-      $result[$event['id']] = $event;
-    }
-    return $result;
-  }
-
-  /**
-   * Register the given contact to the given event
-   */
-  public function registerRemote($event_id, $participant_details = []) {
-    $participant_data = [
-      'event_id' => $event_id,
-    ];
-    foreach ($participant_details as $key => $value) {
-      $participant_data[$key] = $value;
-    }
-
-    return $this->callRemoteEventAPI('RemoteParticipant', 'create', $participant_data);
-  }
-
-  /**
-   * Wrap an API call to fit the status message system
-   *
-   * @param $entity
-   * @param $action
-   * @param $data
-   */
-  protected function callRemoteEventAPI($entity, $action, $data) {
-    // first run
-    try {
-      $result = civicrm_api3($entity, $action, $data);
-      $result['is_error'] = 0;
-      self::assertArrayHasKey(
-        'status_messages',
-        $result,
-        "API Call {$entity}.{$action} doesn't return 'status_messages'"
-      );
-      $status_messages = $result['status_messages'];
-    }
-    catch (CRM_Core_Exception $ex) {
-      $result = [
-        'is_error' => 1,
-        'error_message' => $ex->getMessage(),
-      ];
-      if (isset($ex->getErrorData()['status_messages'])) {
-        $status_messages = $ex->getErrorData()['status_messages'];
-      }
-      else {
-        $status_messages = [];
-      }
-    }
-
-    // extract messages
-    $severity2list = [
-      'error' => 'errors',
-      'warning' => 'warnings',
-      'status' => 'status',
-    ];
-    foreach ($status_messages as $message) {
-      $result[$severity2list[$message['severity']]][] = $message['message'];
-    }
-
-    return $result;
-  }
-
-  /**
-   * Register the given contact to the given event
-   *
-   * @param array $submission
-   */
-  public function updateRegistration($submission) {
-    if (empty($submission['token']) && !empty($submission['participant_id'])) {
-      $token = CRM_Remotetools_SecureToken::generateEntityToken(
-        'Participant',
-        $submission['participant_id'],
-        NULL,
-        'update'
-      );
-      $submission['token'] = $token;
-    }
-    return $this->callRemoteEventAPI('RemoteParticipant', 'update', $submission);
-  }
-
-  /**
-   * Cancel the given registration
-   *
-   * @param array $submission
-   */
-  public function cancelRegistration($submission) {
-    if (empty($submission['token']) && !empty($submission['participant_id'])) {
-      $token = CRM_Remotetools_SecureToken::generateEntityToken(
-        'Participant',
-        $submission['participant_id'],
-        NULL,
-        'cancel'
-      );
-      $submission['token'] = $token;
-    }
-    return $this->callRemoteEventAPI('RemoteParticipant', 'cancel', $submission);
-  }
-
-  /**
-   * Create a number of new contacts
-   *  using the createContact function above
-   *
-   * @param integer $count
-   * @param array $contact_details
-   *
-   * @return array [event_id => $event_data]
-   */
-  public function createContacts($count, $contact_details = []) {
-    $result = [];
-    for ($i = 0; $i < $count; $i++) {
-      $contact = $this->createContact($contact_details);
-      $result[$contact['id']] = $contact;
-    }
-    return $result;
-  }
-
-  /**
-   * Create a new contact
-   *
-   * @param array $contact_details
-   *   overrides the default values
-   *
-   * @return array
-   *   contact data
-   */
-  public function createContact($contact_details = []) {
-    // prepare event
-    $contact_data = [
-      'contact_type' => 'Individual',
-      'first_name' => $this->randomString(10),
-      'last_name' => $this->randomString(10),
-      'email' => $this->randomString(10) . '@' . $this->randomString(10) . '.org',
-      'prefix_id' => 1,
-    ];
-    foreach ($contact_details as $key => $value) {
-      $contact_data[$key] = $value;
-    }
-    CRM_Remoteevent_CustomData::resolveCustomFields($contact_data);
-
-    // create contact
-    $result = $this->traitCallAPISuccess('Contact', 'create', $contact_data);
-    $contact = $this->traitCallAPISuccess('Contact', 'getsingle', ['id' => $result['id']]);
-    CRM_Remoteevent_CustomData::labelCustomFields($contact);
-    return $contact;
-  }
-
-  /**
-   * Set a value for the speaker roles
-   *
-   * @param array $value
-   *   a list of role_ids or empty for disabled
-   */
-  public function setSpeakerRoles($value) {
-    Civi::settings()->set('remote_registration_speaker_roles', $value);
-  }
-
-  /**
-   * Use the RemoteEvent.get API to event information
-   *
-   * @phpstan-param list<int> $event_ids
-   *   list of event_ids
-   *
-   * @phpstan-return list<array<string, mixed>>
-   */
-  public function getRemoteEvents(array $event_ids): array {
-    return array_map([$this, 'getRemoteEvent'], $event_ids);
-  }
-
-  /**
-   * Use the RemoteEvent.get API to event information
-   *
-   * @param integer $event_id
-   *   event id
-   *
-   * @param array $params
-   *   additional parameters
-   */
-  public function getRemoteEvent($event_id, $params = []) {
-    $params['id'] = $event_id;
-    return $this->traitCallAPISuccess('RemoteEvent', 'getsingle', $params);
-  }
-
-  /**
-   * Use the RemoteEvent.get API to find events
-   *
-   * @param array $params
-   *   search parameters
-   */
-  public function findRemoteEvents($params = []) {
-    return $this->traitCallAPISuccess('RemoteEvent', 'get', $params);
-  }
-
-  /**
-   * Get a random value subset of the array
-   *
-   * @param array $array
-   *   the array to pick the values
-   *
-   * @param integer $count
-   *   number of elements to pick, will be randomised if not given
-   *
-   * @return array
-   *   subset (keys not retained)
-   */
-  public function randomSubset($array, $count = NULL) {
-    if ($count === NULL) {
-      $count = mt_rand(1, count($array) - 1);
-    }
 
   /**
    * @phpstan-return list<array<string, mixed>>
@@ -513,22 +237,20 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
      *   overrides the default values
      *
      * @return array
-     *  contact data
+     *   contact data
      */
-    public function createEventSession($event_id, $session_details = [])
-    {
+  public function createEventSession($event_id, $session_details = []) {
         // prepare event
         $session_data = [
-            'event_id'         => $event_id,
-            'title'            => $this->randomString(50),
-            'is_active'        => 1,
-            'start_date'       => $this->getUniqueDateTime(),
-            'end_date'         => $this->getUniqueDateTime(),
-            //'slot_id'        => '',
-            'category_id'      => 1,
-            'type_id'          => 1,
-            'description'      => $this->randomString(50),
-            'max_participants' => null,
+      'event_id' => $event_id,
+      'title' => $this->randomString(50),
+      'is_active' => 1,
+      'start_date' => $this->getUniqueDateTime(),
+      'end_date' => $this->getUniqueDateTime(),
+      'category_id' => 1,
+      'type_id' => 1,
+      'description' => $this->randomString(50),
+      'max_participants' => NULL,
         ];
         foreach ($session_details as $key => $value) {
             $session_data[$key] = $value;
@@ -538,6 +260,281 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
         $result = $this->traitCallAPISuccess('Session', 'create', $session_data);
         $session = $this->traitCallAPISuccess('Session', 'getsingle', ['id' => $result['id']]);
         return $session;
+    }
+
+  /**
+   * Create a number of events with the same setup,
+   *   using the createRemoteEvent function
+   *
+   * @param integer $count
+   * @param array $event_details
+   *
+   * @return array [event_id => $event_data]
+   */
+  public function createRemoteEvents($count, $event_details = []) {
+    $result = [];
+    for ($i = 0; $i < $count; $i++) {
+      $event = $this->createRemoteEvent($event_details);
+      $result[$event['id']] = $event;
+    }
+    return $result;
+  }
+
+  /**
+   * Register the given contact to the given event
+   */
+  public function registerRemote($event_id, $participant_details = []) {
+    $participant_data = [
+      'event_id' => $event_id,
+    ];
+    foreach ($participant_details as $key => $value) {
+      $participant_data[$key] = $value;
+    }
+
+    return $this->callRemoteEventAPI('RemoteParticipant', 'create', $participant_data);
+  }
+
+  /**
+   * Wrap an API call to fit the status message system
+   *
+   * @param $entity
+   * @param $action
+   * @param $data
+   */
+  protected function callRemoteEventAPI($entity, $action, $data) {
+    // first run
+    try {
+      $result = civicrm_api3($entity, $action, $data);
+      $result['is_error'] = 0;
+      self::assertArrayHasKey(
+        'status_messages',
+        $result,
+        "API Call {$entity}.{$action} doesn't return 'status_messages'"
+      );
+      $status_messages = $result['status_messages'];
+    } catch (CRM_Core_Exception $ex) {
+      $result = [
+        'is_error' => 1,
+        'error_message' => $ex->getMessage(),
+      ];
+      if (isset($ex->getErrorData()['status_messages'])) {
+        $status_messages = $ex->getErrorData()['status_messages'];
+      } else {
+        $status_messages = [];
+      }
+    }
+
+    // extract messages
+    $severity2list = [
+      'error' => 'errors',
+      'warning' => 'warnings',
+      'status' => 'status',
+    ];
+    foreach ($status_messages as $message) {
+      $result[$severity2list[$message['severity']]][] = $message['message'];
+    }
+
+    return $result;
+  }
+
+  /**
+   * Register the given contact to the given event
+   *
+   * @param array $submission
+   */
+  public function updateRegistration($submission) {
+    if (empty($submission['token']) && !empty($submission['participant_id'])) {
+      $token = CRM_Remotetools_SecureToken::generateEntityToken(
+        'Participant',
+        $submission['participant_id'],
+        NULL,
+        'update'
+      );
+      $submission['token'] = $token;
+    }
+    return $this->callRemoteEventAPI('RemoteParticipant', 'update', $submission);
+  }
+
+  /**
+   * Cancel the given registration
+   *
+   * @param array $submission
+   */
+  public function cancelRegistration($submission) {
+    if (empty($submission['token']) && !empty($submission['participant_id'])) {
+      $token = CRM_Remotetools_SecureToken::generateEntityToken(
+        'Participant',
+        $submission['participant_id'],
+        NULL,
+        'cancel'
+      );
+      $submission['token'] = $token;
+    }
+    return $this->callRemoteEventAPI('RemoteParticipant', 'cancel', $submission);
+  }
+
+  /**
+   * Create a new contact
+   *
+   * @param array $contact_details
+   *   overrides the default values
+   *
+   * @return array
+   *   contact data
+   */
+  public function createContact($contact_details = []) {
+    // prepare event
+    $contact_data = [
+      'contact_type' => 'Individual',
+      'first_name' => $this->randomString(10),
+      'last_name' => $this->randomString(10),
+      'email' => $this->randomString(10) . '@' . $this->randomString(10) . '.org',
+      'prefix_id' => 1,
+    ];
+    foreach ($contact_details as $key => $value) {
+      $contact_data[$key] = $value;
+    }
+    CRM_Remoteevent_CustomData::resolveCustomFields($contact_data);
+
+    // create contact
+    $result = $this->traitCallAPISuccess('Contact', 'create', $contact_data);
+    $contact = $this->traitCallAPISuccess('Contact', 'getsingle', ['id' => $result['id']]);
+    CRM_Remoteevent_CustomData::labelCustomFields($contact);
+    return $contact;
+  }
+
+  /**
+   * Create a number of new contacts
+   *  using the createContact function above
+   *
+   * @param integer $count
+   * @param array $contact_details
+   *
+   * @return array [event_id => $event_data]
+   */
+  public function createContacts($count, $contact_details = []) {
+    $result = [];
+    for ($i = 0; $i < $count; $i++) {
+      $contact = $this->createContact($contact_details);
+      $result[$contact['id']] = $contact;
+    }
+    return $result;
+  }
+
+  /**
+   * Generate a random string, and make sure we don't collide
+   *
+   * @param int $length
+   *   length of the string
+   *
+   * @return string
+   *   random string
+   */
+  public function randomString($length = 32) {
+    static $generated_strings = [];
+    $candidate = substr(sha1(random_bytes(32)), 0, $length);
+    if (isset($generated_strings[$candidate])) {
+      // simply try again (recursively). Is this dangerous? Yes, but veeeery unlikely... :)
+      return $this->randomString($length);
+    }
+    // mark as 'generated':
+    $generated_strings[$candidate] = 1;
+    return $candidate;
+  }
+
+  /**
+   * Make sure the given profile exists, and has
+   *   a basic amount of matching options
+   *
+   * @param string $profile_name
+   *   name of the profile
+   * @param array $profile_data_override
+   *   XCM profile spec that differs from the default
+   */
+  public function setUpXCMProfile($profile_name, $profile_data_override = NULL) {
+    // set profile
+    /** @phpstan-var array<string, array<string, mixed>> $profiles */
+    $profiles = Civi::settings()->get('xcm_config_profiles');
+    if (NULL !== $profile_data_override && [] !== $profile_data_override) {
+      $profiles[$profile_name] = $profile_data_override;
+    } else {
+      $profileJson = file_get_contents(E::path('tests/resources/xcm_profile_testing.json'));
+      if (FALSE !== $profileJson) {
+        $profiles[$profile_name] = json_decode(
+          $profileJson,
+          TRUE
+        );
+      }
+    }
+    Civi::settings()->set('xcm_config_profiles', $profiles);
+  }
+
+  /**
+   * Set a value for the speaker roles
+   *
+   * @param array $value
+   *   a list of role_ids or empty for disabled
+   */
+  public function setSpeakerRoles($value): void {
+    Civi::settings()->set('remote_registration_speaker_roles', $value);
+  }
+
+  /**
+   * Use the RemoteEvent.get API to event information
+   *
+   * @phpstan-param list<int> $event_ids
+   *   list of event_ids
+   *
+   * @phpstan-return list<array<string, mixed>>
+   */
+  public function getRemoteEvents(array $event_ids): array {
+    return array_map([$this, 'getRemoteEvent'], $event_ids);
+  }
+
+  /**
+   * Use the RemoteEvent.get API to event information
+   *
+   * @param integer $event_id
+   *   event id
+   *
+   * @param array $params
+   *   additional parameters
+   */
+  public function getRemoteEvent($event_id, $params = []) {
+    $params['id'] = $event_id;
+    return $this->traitCallAPISuccess('RemoteEvent', 'getsingle', $params);
+  }
+
+  /**
+   * Use the RemoteEvent.get API to find events
+   *
+   * @param array $params
+   *   search parameters
+   */
+  public function findRemoteEvents($params = []) {
+    return $this->traitCallAPISuccess('RemoteEvent', 'get', $params);
+  }
+
+  /**
+   * Get a random value subset of the array
+   *
+   * @param array $array
+   *   the array to pick the values
+   *
+   * @param integer $count
+   *   number of elements to pick, will be randomised if not given
+   *
+   * @return array
+   *   subset (keys not retained)
+   */
+  public function randomSubset($array, $count = NULL) {
+    if ($count === NULL) {
+      $count = mt_rand(1, count($array) - 1);
+    }
+
+    $random_keys = array_rand($array, $count);
+    if (!is_array($random_keys)) {
+      $random_keys = [$random_keys];
     }
 
     // create result array
@@ -559,23 +556,19 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
    */
   public function getRemoteContactKey($contact_id) {
     $contact_id = (int) $contact_id;
-    $key = CRM_Core_DAO::singleValueQuery(
-      "
-            SELECT identifier
-            FROM civicrm_value_contact_id_history
-            WHERE identifier_type = 'remote_contact'
-              AND entity_id = {$contact_id}
-            LIMIT 1
-        "
-    );
+    $key = CRM_Core_DAO::singleValueQuery("
+      SELECT identifier
+      FROM civicrm_value_contact_id_history
+      WHERE identifier_type = 'remote_contact'
+        AND entity_id = {$contact_id}
+      LIMIT 1
+    ");
     if (!$key) {
       $key = $this->randomString();
-      CRM_Core_DAO::executeQuery(
-        "
-                INSERT INTO civicrm_value_contact_id_history (entity_id, identifier, identifier_type, used_since)
-                VALUES ({$contact_id}, '{$key}', 'remote_contact', NOW())
-            "
-      );
+      CRM_Core_DAO::executeQuery("
+        INSERT INTO civicrm_value_contact_id_history (entity_id, identifier, identifier_type, used_since)
+        VALUES ({$contact_id}, '{$key}', 'remote_contact', NOW())
+      ");
     }
 
     $verify_contact_id = CRM_Remotetools_Contact::getByKey($key);
@@ -628,7 +621,7 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
    * @param string $failure_msg
    *   message to log in case of failure
    */
-  public function assertParticipantStatus($participant_id, $participant_status, $failure_msg) {
+  public function assertParticipantStatus($participant_id, $participant_status, $failure_msg): void {
     $participant = $this->traitCallAPISuccess('Participant', 'get', ['id' => $participant_id]);
     self::assertGreaterThan(0, $participant['count'], $failure_msg . " (doesn't exist)");
     self::assertLessThan(2, $participant['count'], $failure_msg . ' (ambiguous)');
@@ -654,7 +647,7 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     if ($reset_cache) {
       $participant_statuses = NULL;
     }
-    if ($participant_statuses === NULL) {
+    if (NULL === $participant_statuses) {
       $participant_statuses = [];
       $query = civicrm_api3(
         'ParticipantStatusType',
@@ -700,6 +693,17 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     }
   }
 
+  public function assertGetFormPriceFields(&$fields, $priceFields): void {
+    foreach ($priceFields as $priceField) {
+      $formFieldName = 'price_' . $priceField['name'];
+      $this->assertArrayHasKey(
+        $formFieldName,
+        $fields,
+        sprintf("RemoteContact.get_form should contain '%s' field", $formFieldName)
+      );
+    }
+  }
+
   /**
    * Create a new, unique campaign
    */
@@ -716,6 +720,23 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
       ]
     );
     return $this->traitCallAPISuccess('Campaign', 'getsingle', ['id' => $campaign['id']]);
+  }
+
+  /**
+   * Get a (within this test) unique
+   *  timestamp. It starts with now+1h and
+   *  increments in 5 minute interval
+   *
+   * @return string timestamp
+   */
+  public function getUniqueDateTime() {
+    static $last_timestamp = NULL;
+    if (NULL === $last_timestamp) {
+      $last_timestamp = strtotime('now + 1 hour');
+    } else {
+      $last_timestamp = strtotime('+5 minutes', $last_timestamp);
+    }
+    return date('YmdHis', $last_timestamp);
   }
 
   /**
@@ -754,182 +775,4 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     }
     return $result;
   }
-
-  protected function setUp(): void {
-    parent::setUp();
-    CRM_Xcm_Configuration::flushProfileCache();
-    $this->transaction = new CRM_Core_Transaction();
-    $this->setUpXCMProfile('default');
-
-    $profile = CRM_Xcm_Configuration::getConfigProfile('default');
-
-    // jumble the participant status labels so we're sure we only using the names
-    CRM_Core_DAO::executeQuery('UPDATE civicrm_participant_status_type SET label = MD5(name);');
-  }
-
-  /**
-   * Make sure the given profile exists, and has
-   *   a basic amount of matching options
-   *
-   * @param string $profile_name
-   *   name of the profile
-   * @param array $profile_data_override
-   *   XCM profile spec that differs from the default
-   */
-  public function setUpXCMProfile($profile_name, $profile_data_override = NULL) {
-    // set profile
-    /** @phpstan-var array<string, array<string, mixed>> $profiles */
-    $profiles = Civi::settings()->get('xcm_config_profiles');
-    if (NULL !== $profile_data_override && [] !== $profile_data_override) {
-      $profiles[$profile_name] = $profile_data_override;
-    }
-    else {
-      $profileJson = file_get_contents(E::path('tests/resources/xcm_profile_testing.json'));
-      if (FALSE !== $profileJson) {
-        $profiles[$profile_name] = json_decode(
-          $profileJson,
-          TRUE
-        );
-      }
-    }
-    Civi::settings()->set('xcm_config_profiles', $profiles);
-  }
-
-  protected function tearDown(): void {
-    $this->transaction->rollback();
-    $this->transaction = NULL;
-    CRM_Remoteevent_CustomData::flushCashes();
-    parent::tearDown();
-  }
-
-        $this->assertArrayHasKey($status_name, $participant_statuses, "Participant status '{$status_name} doesn't exist.");
-        return $participant_statuses[$status_name];
-    }
-
-    /**
-     * Verify that the participant object has the right status
-     *
-     * @param integer $participant_id
-     *   the participant ID
-     * @param integer|string $participant_status
-     *   the expected participant status
-     * @param string $failure_msg
-     *   message to log in case of failure
-     */
-    public function assertParticipantStatus($participant_id, $participant_status, $failure_msg)
-    {
-        $participant = $this->traitCallAPISuccess('Participant', 'get', ['id' => $participant_id]);
-        $this->assertGreaterThan(0, $participant['count'], $failure_msg . " (doesn't exist)");
-        $this->assertLessThan(2, $participant['count'], $failure_msg . " (ambiguous)");
-        $participant = reset($participant['values']);
-
-        $this->assertEquals($this->getParticipantStatusId($participant_status, true), $participant['participant_status_id'], $failure_msg);
-    }
-
-    /**
-     * Verify that the RemoteContact.get_form standard 'fields' are there
-     *
-     * @param array $fields
-     *   the fields reported by the get_form
-     * @param boolean $strip_fields
-     *   if true, the standard fields are removed from the $fields array
-     */
-    public function assertGetFormStandardFields(&$fields, $strip_fields = false)
-    {
-        // todo: check more?
-        $this->assertArrayHasKey('event_id', $fields, "RemoteContact.get_form should contain 'event_id' field");
-        $field_spec = $fields['event_id'];
-        $this->assertArrayHasKey('profile', $fields, "RemoteContact.get_form should contain 'profile' field");
-        $field_spec = $fields['profile'];
-        $this->assertArrayHasKey('remote_contact_id', $fields, "RemoteContact.get_form should contain 'remote_contact_id' field");
-        $field_spec = $fields['remote_contact_id'];
-
-        if ($strip_fields) {
-            unset($fields['event_id']);
-            unset($fields['profile']);
-            unset($fields['remote_contact_id']);
-        }
-    }
-
-    public function assertGetFormPriceFields(&$fields, $priceFields): void {
-      foreach ($priceFields as $priceField) {
-        $formFieldName = 'price_' . $priceField['name'];
-        $this->assertArrayHasKey(
-          $formFieldName,
-          $fields,
-          sprintf("RemoteContact.get_form should contain '%s' field", $formFieldName)
-        );
-      }
-    }
-
-    /**
-     * Create a new, unique campaign
-     */
-    public function getCampaign() {
-        $campaign_name = $this->randomString();
-        $campaign = $this->traitCallAPISuccess('Campaign', 'create', [
-            'name' => $campaign_name,
-            'title' => $campaign_name,
-            'campaign_type_id' => 1,
-            'status_id' => 1,
-        ]);
-        return $this->traitCallAPISuccess('Campaign', 'getsingle', ['id' => $campaign['id']]);
-    }
-
-    /**
-     * Get a (within this test) unique
-     *  timestamp. It starts with now+1h and
-     *  increments in 5 minute interval
-     *
-     * @return string timestamp
-     */
-    public function getUniqueDateTime()
-    {
-        static $last_timestamp = null;
-        if ($last_timestamp === null) {
-            $last_timestamp = strtotime('now + 1 hour');
-        } else {
-            $last_timestamp = strtotime('+5 minutes', $last_timestamp);
-        }
-        return date('YmdHis', $last_timestamp);
-    }
-
-
-    /**
-     * Create an associative array from a list of fields specs in the form of
-     * [
-     *   [
-     *      'name'        => 'some field name',
-     *      'type'        => CRM_Utils_Type::T_STRING,
-     *      'value'       => 'some value',
-     *      'title'       => 'some title',
-     *      'localizable' => 0,
-     *   ],
-     *    ...
-     * ]
-     *
-     * @param array $field_array
-     *    the outer array
-     * @param string $key_field
-     *    the inner field to be used as key
-     * @param string $value_field
-     *    the inner field to be used as value
-     *
-     * @return array
-     *    the extracted associative array
-     */
-    public function mapFieldArray($field_array, $key_field = 'name', $value_field = 'value')
-    {
-        $result = [];
-        foreach ($field_array as $field_spec) {
-            if (!isset($field_spec[$key_field])) {
-                $this->fail("Field array doesn't have key field '{$key_field}'");
-            }
-            if (!isset($field_spec[$value_field])) {
-                $this->fail("Field array doesn't have value field '{$value_field}'");
-            }
-            $result[$field_spec[$key_field]] = $field_spec[$value_field];
-        }
-        return $result;
-    }
 }


### PR DESCRIPTION
- [x] Add price fields to form definition (also for additional participants; on registration only, disallow updating price options for now)
- [x] Process selected price field options (re-implementing Core's event form processing spaghetti code - ideally by moving some of Core's functionality into the API)
- [x] Process deferred payments like CiviSEPA or EFT
- [ ] Process remote payments made on the remote system
- [ ] Add (more) tests
- [ ] Allow for client-side improvements, e.g. live calculation of total amount for registration, including formatting with correct currency

*systopia-reference: 24192*