### PR TITLE
Show validation warning instead of an error if `remote_registration_additional_participants_waitlist` is disabled, but request has no additional participants

### DIFF
--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -204,8 +204,11 @@ abstract class CRM_Remoteevent_RegistrationProfile
             && ($excessParticipants = CRM_Remoteevent_Registration::getRegistrationCount($event['id']) + 1 + $additionalParticipantsCount - $event['max_participants']) > 0
         ) {
             if (
-              !empty($event['has_waitlist'])
-                && ($additionalParticipantsCount === 0 || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist']))
+                !empty($event['has_waitlist'])
+                    && (
+                        $additionalParticipantsCount === 0
+                        || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+                    )
             ) {
                 $validationEvent->addWarning(
                     $l10n->localise('Not enough vacancies for the number of requested participants.')

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -205,7 +205,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
         ) {
             if (
               !empty($event['has_waitlist'])
-              && !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist'])
+                && ($additionalParticipantsCount === 0 || !empty($event['event_remote_registration.remote_registration_additional_participants_waitlist']))
             ) {
                 $validationEvent->addWarning(
                     $l10n->localise('Not enough vacancies for the number of requested participants.')


### PR DESCRIPTION
Note: Needs to be cherry-picked for `2.1` after merging.

@jojowork requesting a functional review due to your bug report

*systopia-reference: 25041*