### PR TITLE
Make custom groups reserved

### DIFF
--- a/CRM/Remoteevent/Upgrader.php
+++ b/CRM/Remoteevent/Upgrader.php
@@ -237,6 +237,23 @@ class CRM_Remoteevent_Upgrader extends CRM_Extension_Upgrader_Base
         return true;
     }
 
+    /**
+     * Synchronizes custom groups to make them reserved. This is necessary since
+     * CiviCRM 5.71.0 because of this change:
+     * https://github.com/civicrm/civicrm-core/commit/1f511cc1a07e0c5e9902b0c053f2c4e4bbf45784
+     *
+     * @throws \Exception
+     */
+    public function upgrade_0019(): bool
+    {
+        $this->ctx->log->info('Updating data structures');
+        $customData = new CRM_Remoteevent_CustomData(E::LONG_NAME);
+        $customData->syncCustomGroup(E::path('resources/custom_group_remote_registration.json'));
+        $customData->syncCustomGroup(E::path('resources/custom_group_alternative_location.json'));
+
+        return TRUE;
+    }
+
 
     /****************************************************************
      **                       HELPER FUNCTIONS                     **

--- a/resources/custom_group_alternative_location.json
+++ b/resources/custom_group_alternative_location.json
@@ -10,7 +10,7 @@
   "style": "Tab",
   "table_name": "civicrm_value_event_alternative_location",
   "collapse_adv_display": "0",
-  "is_reserved": "0",
+  "is_reserved": "1",
   "_fields": [
     {
       "_lookup": ["column_name", "custom_group_id"],

--- a/resources/custom_group_remote_registration.json
+++ b/resources/custom_group_remote_registration.json
@@ -10,7 +10,7 @@
   "style": "Tab",
   "table_name": "civicrm_value_remote_registration",
   "collapse_adv_display": "0",
-  "is_reserved": "0",
+  "is_reserved": "1",
   "_fields": [
     {
       "_lookup": ["column_name", "custom_group_id"],


### PR DESCRIPTION
Edit: In contrast to the initial claim, this doesn't fix the problem with custom field values reset on the Information tab of the event form https://lab.civicrm.org/dev/core/-/issues/5238

Nevertheless, I think this change makes sense.

systopia-reference: 25017