### PR TITLE
Count all registrations with active count flag by default

### DIFF
--- a/CRM/Remoteevent/EventFlags.php
+++ b/CRM/Remoteevent/EventFlags.php
@@ -213,8 +213,13 @@ class CRM_Remoteevent_EventFlags
                 // PERSONALISED OVERRIDES
                 $valid_participant_registrations_count =
                     CRM_Remoteevent_Registration::getRegistrationCount($event['id'], $contact_id, ['Positive']);
-                $all_participant_registrations_count =
-                    CRM_Remoteevent_Registration::getRegistrationCount($event['id'], $contact_id, ['Positive', 'Pending'], [], false);
+                $all_participant_registrations_count = CRM_Remoteevent_Registration::getRegistrationCount(
+                    $event['id'],
+                    $contact_id,
+                    ['Positive', 'Pending', 'Waiting'],
+                    [],
+                    FALSE
+                );
                 $event['participant_registration_count'] = $valid_participant_registrations_count;
                 $event['is_registered'] = (int) ($valid_participant_registrations_count > 0);
                 $event['can_edit_registration'] = (int)($event['can_edit_registration'] && ($all_participant_registrations_count > 0));

--- a/CRM/Remoteevent/EventFlags.php
+++ b/CRM/Remoteevent/EventFlags.php
@@ -212,10 +212,10 @@ class CRM_Remoteevent_EventFlags
             if ($contact_id) {
                 // PERSONALISED OVERRIDES
                 $valid_participant_registrations_count =
-                    CRM_Remoteevent_Registration::getRegistrationCount($event['id'], $contact_id);
+                    CRM_Remoteevent_Registration::getRegistrationCount($event['id'], $contact_id, ['Positive']);
                 $all_participant_registrations_count =
                     CRM_Remoteevent_Registration::getRegistrationCount($event['id'], $contact_id, ['Positive', 'Pending'], [], false);
-                $event['participant_registration_count'] = (int) $valid_participant_registrations_count;
+                $event['participant_registration_count'] = $valid_participant_registrations_count;
                 $event['is_registered'] = (int) ($valid_participant_registrations_count > 0);
                 $event['can_edit_registration'] = (int)($event['can_edit_registration'] && ($all_participant_registrations_count > 0));
                 $event['can_cancel_registration'] = (int)($event['can_cancel_registration'] && ($all_participant_registrations_count > 0));

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -196,15 +196,15 @@ class CRM_Remoteevent_Registration
         }
 
         // check if max_participants set and NO waitlist:
-        if (!empty($event_data['max_participants'])) {
-          $registered_count = self::getRegistrationCount($event_id);
-          if ($registered_count >= $event_data['max_participants']) {
-            if (empty($event_data['event_full_text'])) {
-              return E::ts("Event is booked out");
-            } else {
-              return $event_data['event_full_text'];
+        if (!empty($event_data['max_participants']) && empty($event_data['has_waitlist'])) {
+            $registered_count = self::getRegistrationCount($event_id);
+            if ($registered_count >= $event_data['max_participants']) {
+                if (empty($event_data['event_full_text'])) {
+                    return E::ts("Event is booked out");
+                } else {
+                    return $event_data['event_full_text'];
+                }
             }
-          }
         }
 
         // check if this contact already registered

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -196,21 +196,21 @@ class CRM_Remoteevent_Registration
         }
 
         // check if max_participants set and NO waitlist:
-        if (!empty($event_data['max_participants']) && empty($event_data['has_waitlist'])) {
-            $registered_count = self::getRegistrationCount($event_id);
-            if ($registered_count >= $event_data['max_participants']) {
-                if (empty($event_data['event_full_text'])) {
-                    return E::ts("Event is booked out");
-                } else {
-                    return $event_data['event_full_text'];
-                }
+        if (!empty($event_data['max_participants'])) {
+          $registered_count = self::getRegistrationCount($event_id);
+          if ($registered_count >= $event_data['max_participants']) {
+            if (empty($event_data['event_full_text'])) {
+              return E::ts("Event is booked out");
+            } else {
+              return $event_data['event_full_text'];
             }
+          }
         }
 
         // check if this contact already registered
         // todo: if this is an invite only event, then we need instead see if there _is_ a pending contribution
         if ($contact_id) {
-            $registered_count = self::getRegistrationCount($event_id, $contact_id, ['Positive', 'Pending']);
+            $registered_count = self::getRegistrationCount($event_id, $contact_id);
             if ($registered_count > 0) {
                 return E::ts("Contact is already registered");
             }
@@ -444,9 +444,9 @@ class CRM_Remoteevent_Registration
         $contact_id = (int) $contact_id;
 
         // compile query
-        $class_list = array_intersect(['Positive', 'Pending', 'Negative'], $class_list);
+        $class_list = array_intersect(['Positive', 'Pending', 'Negative', 'Waiting'], $class_list);
         if (empty($class_list)) {
-            $REGISTRATION_CLASSES = "('Positive', 'Pending', 'Negative')";
+            $REGISTRATION_CLASSES = "('Positive', 'Pending', 'Negative', 'Waiting')";
         } else {
             $REGISTRATION_CLASSES = "('" . implode("','", $class_list) . "')";
         }

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -433,8 +433,13 @@ class CRM_Remoteevent_Registration
      * @return int
      *    number of registrations (participant objects)
      */
-    public static function getRegistrationCount($event_id, $contact_id = null, $class_list = ['Positive'], $status_id_list = [], $only_counted = true)
-    {
+    public static function getRegistrationCount(
+        $event_id,
+        $contact_id = null,
+        array $class_list = [],
+        array $status_id_list = [],
+        bool $only_counted = true
+    ): int {
         $event_id = (int) $event_id;
         $contact_id = (int) $contact_id;
 

--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -202,7 +202,10 @@ abstract class CRM_Remoteevent_RegistrationProfile
         // Validate number of participants.
         if (
             !empty($event['max_participants'])
-            && ($excessParticipants = CRM_Remoteevent_Registration::getRegistrationCount($event['id']) + 1 + $additionalParticipantsCount - $event['max_participants']) > 0
+            && ($excessParticipants =
+              CRM_Remoteevent_Registration::getRegistrationCount($event['id'])
+              + 1 + $additionalParticipantsCount - $event['max_participants'])
+            > 0
         ) {
             if (
                 !empty($event['has_waitlist'])

--- a/CRM/Remoteevent/RemoteEvent.php
+++ b/CRM/Remoteevent/RemoteEvent.php
@@ -245,7 +245,11 @@ class CRM_Remoteevent_RemoteEvent
 
         if (!empty($event_data['has_waitlist']) && !empty($event_data['max_participants'])) {
             // there is an active waiting list, see if we need to get on it
-            $registered_count = CRM_Remoteevent_Registration::getRegistrationCount($event_id);
+            $registered_count = CRM_Remoteevent_Registration::getRegistrationCount(
+                $event_id,
+                NULL,
+                ['Positive', 'Pending']
+            );
             return ($registered_count >= $event_data['max_participants']);
         } else {
             return false;

--- a/api/v3/RemoteEvent/Get.php
+++ b/api/v3/RemoteEvent/Get.php
@@ -111,7 +111,15 @@ function civicrm_api3_remote_event_get($params)
         // add counts and other data
         $event['event_type'] =
             CRM_Remoteevent_RemoteEvent::getEventType($event, $result->getLocalisation());
+        // Historically, "registration_count" only included registration with a
+        // "Positive" status, counting all participants that are "really"
+        // registered, which we want to keep that way.
         $event['registration_count'] =
+            CRM_Remoteevent_Registration::getRegistrationCount($event['id'], NULL, ['Positive']);
+        // "registration_count_all" denotes all registration with a status that
+        // has the "is_counted" flag, regardless of status classes, i.e.
+        // including waitlisted or pending registrations.
+        $event['registration_count_all'] =
             CRM_Remoteevent_Registration::getRegistrationCount($event['id']);
     }
 


### PR DESCRIPTION
The number returned by `Registration::getRegistrationCount()` previously counted only 'Positive' registrations *with* active count flag. Having the count flag makes it counterintuitive if the default doesn't count all registrations with active count flag.

This assumption was obviously made when the waitlist feature was implemented which currently doesn't behave as expected.

I've checked the calls of `Registration::getRegistrationCount()` and changed one call. Though I'm not quiet sure if it is correct. Please check the other calls of the method if adjustment is necessary.

systopia-reference: 25017