### PR TITLE
Refactor localization for not changing UF locale for each string

### DIFF
--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -134,13 +134,13 @@ class CRM_Remoteevent_Localisation
 
     protected static function getI18n(string $tsLocale): CRM_Core_I18n
     {
-        if (!isset(Civi::$statics[__CLASS__]['singleton'])) {
-            Civi::$statics[__CLASS__]['singleton'] = [];
+        if (!isset(Civi::$statics[CRM_Core_I18n::class]['singleton'])) {
+            Civi::$statics[CRM_Core_I18n::class]['singleton'] = [];
         }
-        if (!isset(Civi::$statics[__CLASS__]['singleton'][$tsLocale])) {
-            Civi::$statics[__CLASS__]['singleton'][$tsLocale] = new CRM_Core_I18n($tsLocale);
+        if (!isset(Civi::$statics[CRM_Core_I18n::class]['singleton'][$tsLocale])) {
+            Civi::$statics[CRM_Core_I18n::class]['singleton'][$tsLocale] = new CRM_Core_I18n($tsLocale);
         }
 
-        return Civi::$statics[__CLASS__]['singleton'][$tsLocale];
+        return Civi::$statics[CRM_Core_I18n::class]['singleton'][$tsLocale];
     }
 }

--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -44,7 +44,7 @@ class CRM_Remoteevent_Localisation
     public static function getLocalisation($locale = null)
     {
         // default to current locale
-        if ($locale == 'default') {
+        if (!isset($locale) || 'default' === $locale) {
             $locale = CRM_Core_I18n::getLocale();
         }
 
@@ -92,27 +92,27 @@ class CRM_Remoteevent_Localisation
      */
     public function ts($text, $params = [])
     {
-        if (empty($this->locale)) {
-            // No changes, used for pot extraction.
-            return $text;
+        if (!isset($this->locale)) {
+          // No changes, used for pot extraction.
+          return $text;
         }
-        else {
-            static $bootstrapReady = FALSE;
-            static $lastLocale = NULL;
-            static $i18n = NULL;
-            static $function = NULL;
 
-            // TODO: Actually, this is obsolete, as custom translation functions
-            //       don't take the locale as an argument.
-            // When the settings become available, lookup customTranslateFunction.
-            if (!$bootstrapReady) {
-                $bootstrapReady = (bool) \Civi\Core\Container::isContainerBooted();
-                if ($bootstrapReady) {
-                    // just got ready: determine whether there is a working custom translation function
-                    $config = CRM_Core_Config::singleton();
-                    if (!empty($config->customTranslateFunction) && function_exists($config->customTranslateFunction)) {
-                        $function = $config->customTranslateFunction;
-                    }
+        static $bootstrapReady = FALSE;
+        static $lastLocale = NULL;
+        static $i18n = NULL;
+        static $function = NULL;
+
+        // TODO: Actually, this is obsolete, as custom translation functions
+        //       don't take the locale as an argument.
+        // When the settings become available, lookup customTranslateFunction.
+        if (!$bootstrapReady) {
+            $bootstrapReady = (bool) \Civi\Core\Container::isContainerBooted();
+            if ($bootstrapReady) {
+                // just got ready: determine whether there is a working custom translation function
+                $config = CRM_Core_Config::singleton();
+                if (!empty($config->customTranslateFunction) && function_exists($config->customTranslateFunction)) {
+                  $function = $config->customTranslateFunction;
+                }
             }
         }
 
@@ -120,15 +120,14 @@ class CRM_Remoteevent_Localisation
         $requestedLocale = $this->locale;
         if (!$i18n or $lastLocale != $requestedLocale) {
             $i18n = self::getI18n($requestedLocale);
-                $lastLocale = $requestedLocale;
-            }
+            $lastLocale = $requestedLocale;
+        }
 
-            if ($function) {
-                return $function($text, $params);
-            }
-            else {
-                return $i18n->crm_translate($text, $params);
-            }
+        if ($function) {
+            return $function($text, $params);
+        }
+        else {
+            return $i18n->crm_translate($text, $params);
         }
     }
 

--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -79,10 +79,10 @@ class CRM_Remoteevent_Localisation
     /**
      * Localise a given string with this localisation.
      *
-     * @param string $string
+     * @param string $text
      *   The (English) string to localise.
      *
-     * @param array $context
+     * @param array $params
      *   Localisation parameters or variables.
      *
      * @return string
@@ -90,20 +90,57 @@ class CRM_Remoteevent_Localisation
      *
      * @see \ts()
      */
-    public function ts($string, $context = []) {
+    public function ts($text, $params = [])
+    {
         if (empty($this->locale)) {
             // No changes, used for pot extraction.
-            return $string;
+            return $text;
         }
         else {
-          // TODO: Implement a cache, as this gets slow for fields with many
-          //       options, e.g. countries and provinces
-            $currentLocale = CRM_Core_I18n::getLocale();
-            $locale = CRM_Core_I18n::singleton();
-            $locale->setLocale($this->locale);
-            $localizedString = E::ts($string, $context);
-            $locale->setLocale($currentLocale);
-            return $localizedString;
+            static $bootstrapReady = FALSE;
+            static $lastLocale = NULL;
+            static $i18n = NULL;
+            static $function = NULL;
+
+            // TODO: Actually, this is obsolete, as custom translation functions
+            //       don't take the locale as an argument.
+            // When the settings become available, lookup customTranslateFunction.
+            if (!$bootstrapReady) {
+                $bootstrapReady = (bool) \Civi\Core\Container::isContainerBooted();
+                if ($bootstrapReady) {
+                    // just got ready: determine whether there is a working custom translation function
+                    $config = CRM_Core_Config::singleton();
+                    if (!empty($config->customTranslateFunction) && function_exists($config->customTranslateFunction)) {
+                        $function = $config->customTranslateFunction;
+                    }
+                }
+            }
+
+            $params['domain'] ??= E::LONG_NAME;
+            $requestedLocale = $this->locale;
+            if (!$i18n or $lastLocale != $requestedLocale) {
+                $i18n = self::getI18n($requestedLocale);
+                $lastLocale = $requestedLocale;
+            }
+
+            if ($function) {
+                return $function($text, $params);
+            }
+            else {
+                return $i18n->crm_translate($text, $params);
+            }
         }
+    }
+
+    protected static function getI18n(string $tsLocale): CRM_Core_I18n
+    {
+        if (!isset(Civi::$statics[__CLASS__]['singleton'])) {
+            Civi::$statics[__CLASS__]['singleton'] = [];
+        }
+        if (!isset(Civi::$statics[__CLASS__]['singleton'][$tsLocale])) {
+            Civi::$statics[__CLASS__]['singleton'][$tsLocale] = new CRM_Core_I18n($tsLocale);
+        }
+
+        return Civi::$statics[__CLASS__]['singleton'][$tsLocale];
     }
 }

--- a/CRM/Remoteevent/Localisation.php
+++ b/CRM/Remoteevent/Localisation.php
@@ -113,13 +113,13 @@ class CRM_Remoteevent_Localisation
                     if (!empty($config->customTranslateFunction) && function_exists($config->customTranslateFunction)) {
                         $function = $config->customTranslateFunction;
                     }
-                }
             }
+        }
 
-            $params['domain'] ??= E::LONG_NAME;
-            $requestedLocale = $this->locale;
-            if (!$i18n or $lastLocale != $requestedLocale) {
-                $i18n = self::getI18n($requestedLocale);
+        $params['domain'] ??= [E::LONG_NAME, NULL];
+        $requestedLocale = $this->locale;
+        if (!$i18n or $lastLocale != $requestedLocale) {
+            $i18n = self::getI18n($requestedLocale);
                 $lastLocale = $requestedLocale;
             }
 


### PR DESCRIPTION
This should drastically improve performance for localized remote event forms with many fields/many field options.

Testing should involve a requested locale different from the current default locale (i.e. CiviCRM running in English, requested locale being another language).

This makes use of some code copied from Core's `ts()` function to make it work with locales other than the current default one.

Since localization might get very slow, this should be cherry-picked for the `1.2.x` branch as well.

*systopia-reference: 25219*