### PR TITLE
Fix regression causing additional participants not being registered

### DIFF
--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -125,6 +125,7 @@ abstract class CRM_Remoteevent_RegistrationProfile
                     'description' => E::ts('Registration data for additional participant %1', [1 => $i]),
                 ];
                 foreach ($additional_fields as $additional_field_name => $additional_field) {
+                    $additional_field['entity_field_name'] = $additional_field['name'];
                     $additional_field['name'] = 'additional_' . $i . '_' . $additional_field['name'];
                     $additional_field['parent'] = empty($additional_field['parent']) ? 'additional_' . $i : 'additional_' . $i . '_' . $additional_field['parent'];
                     $fields['additional_' . $i . '_' . $additional_field_name] = $additional_field;

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -92,7 +92,7 @@ final class RegistrationEventFactory
             }
         }
 
-        if ([] === $additionalParticipantsData) {
+        if ([] === $additionalParticipantsData && [] === $additionalContactsData) {
             return;
         }
 


### PR DESCRIPTION
#60 refactored the way fields on contacts and participants are being processed during event registrations, including additional participants. This introduced a regression resulting in additional participants not being registered at all due to
* a missing condition for early-returning during calculation of additional participants' data
* missing entity field names (i.e. stripping `additional_x_` from each field name)

This will have to be merged into `1.2.x` as well.