### PR TITLE
IssuesTest: Use `de_DE` instead of `de` as `locale`

### DIFF
--- a/tests/phpunit/CRM/Remoteevent/IssuesTest.php
+++ b/tests/phpunit/CRM/Remoteevent/IssuesTest.php
@@ -57,7 +57,7 @@ class CRM_RemoteEvent_IssuesTest extends CRM_Remoteevent_TestBase
         CRM_Core_I18n::singleton()->setLocale('de_DE'); // multi-language not yet implemented
         $de_fields = $this->traitCallAPISuccess('RemoteParticipant', 'get_form', [
             'event_id' => $event['id'],
-            'locale' => 'de'
+            'locale' => 'de_DE'
         ])['values'];
         $this->assertTrue(isset($de_fields['country_id']['options']), "Field country_id incomplete");
         $de_country_options = $de_fields['country_id']['options'];


### PR DESCRIPTION
There is only a localization for `de_DE` but not `de`.

This PR makes the localization test pass. However, we should consider changing the localization detection so that not only `de_DE` works, but also `de`. Quick idea: Make a symlink from `de` to `de_DE` and adapt the code so `de` is used if `de_CH` was submitted as `locale` parameter. Though this is out of the scope of this PR.