### PR TITLE
TestBase: Fix method `getRemoteEvents`

### DIFF
--- a/api/v3/RemoteEvent/Get.php
+++ b/api/v3/RemoteEvent/Get.php
@@ -61,7 +61,11 @@ function civicrm_api3_remote_event_get($params)
     // Translate event ID.
     $original_params = $get_params->getOriginalParameters();
     if (!empty($original_params['id'])) {
-      $get_params->setParameter('event_id', $original_params['id']);
+      if (!is_numeric($original_params['id'])) {
+        throw new \InvalidArgumentException('Only a single ID is allowed');
+      }
+
+      $get_params->setParameter('event_id', (int) $original_params['id']);
     }
 
     // dispatch search parameters event

--- a/tests/phpunit/CRM/Remoteevent/TestBase.php
+++ b/tests/phpunit/CRM/Remoteevent/TestBase.php
@@ -403,16 +403,14 @@ abstract class CRM_Remoteevent_TestBase extends \PHPUnit\Framework\TestCase impl
     /**
      * Use the RemoteEvent.get API to event information
      *
-     * @param array $event_ids
+     * @phpstan-param list<int> $event_ids
      *   list of event_ids
+     *
+     * @phpstan-return list<array<string, mixed>>
      */
-    public function getRemoteEvents($event_ids)
+    public function getRemoteEvents(array $event_ids): array
     {
-        $result = $this->traitCallAPISuccess('RemoteEvent', 'get', [
-            'id'         => ['IN' => $event_ids],
-            'sequential' => 0
-        ]);
-        return $result['values'];
+        return array_map([$this, 'getRemoteEvent'], $event_ids);
     }
 
     /**


### PR DESCRIPTION
Operator `IN` is not possible in `RemoteEvent.get`.