### PR TITLE
Add participant status and registration date for additional participants

### DIFF
--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -792,7 +792,7 @@ class CRM_Remoteevent_Registration
         // Create additional participants.
         foreach ($additionalParticipantsData as &$participantData) {
             $participantData['registered_by_id'] = $registration->getParticipantID();
-            $participantData['register_date'] = $registration->getParticipantData()['participant_register_date'];
+            $participantData['register_date'] = date('Y-m-d H:i');
             $participantRegistered = Participant::create(false)
                 ->setValues($participantData)
                 ->execute()

--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -792,6 +792,7 @@ class CRM_Remoteevent_Registration
         // Create additional participants.
         foreach ($additionalParticipantsData as &$participantData) {
             $participantData['registered_by_id'] = $registration->getParticipantID();
+            $participantData['register_date'] = $registration->getParticipantData()['participant_register_date'];
             $participantRegistered = Participant::create(false)
                 ->setValues($participantData)
                 ->execute()

--- a/Civi/RemoteParticipant/RegistrationEventFactory.php
+++ b/Civi/RemoteParticipant/RegistrationEventFactory.php
@@ -120,6 +120,11 @@ final class RegistrationEventFactory
             $contactData['xcm_profile'] = $event['event_remote_registration.remote_registration_additional_participants_xcm_profile'];
             $additionalParticipantsData[$participantNo]['role_id'] ??= $this->getDefaultRoleId($event);
             $additionalParticipantsData[$participantNo]['event_id'] = $submissionData['event_id'];
+
+            // Check if registration requires approval.
+            if (!empty($event['requires_approval'])) {
+                $additionalParticipantsData[$participantNo]['status_id.name'] = 'Awaiting approval';
+            }
         }
 
         $registrationEvent->setAdditionalContactsData($additionalContactsData);


### PR DESCRIPTION
Additional participants do not get the *Approval required* status when they should (and the primary participant does). Additional participants also do not get a registration date (as the primary participant does).

This PR sets the status (as is done for the primary participant via `\CRM_Remoteevent_Registration::determineParticipantStatus()`) and copies the registration date from the primary participant prior to creating the additional participant.

I'm not sure if a check for existing values or values in the submission is necessary here …

*systopia-reference: 26708*