### PR TITLE
Add setting for invitation confirm field default value

### DIFF
--- a/CRM/Remoteevent/Form/Settings.php
+++ b/CRM/Remoteevent/Form/Settings.php
@@ -23,6 +23,7 @@ class CRM_Remoteevent_Form_Settings extends CRM_Core_Form
 {
     const SETTINGS = [
         'remote_registration_blocking_status_list',
+        'remote_registration_invitation_confirm_default_value',
         'remote_registration_speaker_roles',
         'remote_registration_link',
         'remote_registration_modify_link',
@@ -45,6 +46,18 @@ class CRM_Remoteevent_Form_Settings extends CRM_Core_Form
             $this->getNegativeStatusList(),
             false,
             ['class' => 'crm-select2', 'multiple' => 'multiple']
+        );
+
+        $this->add(
+            'select',
+            'remote_registration_invitation_confirm_default_value',
+            E::ts('Default value for confirmation of invitations'),
+            [
+                0 => E::ts('Decline'),
+                1 => E::ts('Accept'),
+            ],
+            true,
+            ['class' => 'crm-select2']
         );
 
         $this->add(
@@ -102,7 +115,7 @@ class CRM_Remoteevent_Form_Settings extends CRM_Core_Form
         );
 
 
-        //        $this->add(
+//        $this->add(
 //            'text',
 //            'remote_registration_link',
 //            E::ts("Registration Link"),

--- a/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
+++ b/Civi/RemoteParticipant/Event/GetCreateParticipantFormEvent.php
@@ -53,8 +53,11 @@ class GetCreateParticipantFormEvent extends GetParticipantFormEventBase
                          'confirm' => [
                              'name'        => 'confirm',
                              'type'        => 'Select',
-                             'options'     => [1 => $l10n->ts('Accept Invitation'),
-                                               0 => $l10n->ts('Decline Invitation')],
+                             'options'     => [
+                                 1 => $l10n->ts('Accept Invitation'),
+                                 0 => $l10n->ts('Decline Invitation'),
+                             ],
+                             'value'       => \Civi::settings()->get('remote_registration_invitation_confirm_default_value') ?? 0,
                              'validation'  => '',
                              'weight'      => -10,
                              'required'    => 1,

--- a/templates/CRM/Remoteevent/Form/Settings.hlp
+++ b/templates/CRM/Remoteevent/Form/Settings.hlp
@@ -17,6 +17,10 @@
   <p>{ts}List of statuses the will prevent a contact from registering again.{/ts}</p>
 {/htxt}
 
+{htxt id='id-remote_registration_invitation_confirm_default_value'}
+  <p>{ts}Event registration forms for invited participants show a field for accepting/declining the invitation. Select which option should be pre-selected.{/ts}</p>
+{/htxt}
+
 {htxt id='id-speaker-roles'}
   <p>{ts}Any roles you select here will cause all participants with this role to be publicly listed as speakers at the event.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Remoteevent/Form/Settings.tpl
+++ b/templates/CRM/Remoteevent/Form/Settings.tpl
@@ -16,9 +16,17 @@
 <div class="crm-block crm-form-block crm-event-manage-eventinfo-form-block">
 
   <div class="crm-section">
-
     <div class="label">{$form.remote_registration_blocking_status_list.label}&nbsp;{help id="id-blocking-status" title=$form.remote_registration_blocking_status_list.label}</div>
     <div class="content">{$form.remote_registration_blocking_status_list.html}</div>
+    <div class="clear"></div>
+  </div>
+
+  <div class="crm-section">
+    <div class="label">
+      {$form.remote_registration_invitation_confirm_default_value.label}
+      {help id="id-remote_registration_invitation_confirm_default_value" title=$form.remote_registration_invitation_confirm_default_value.label}
+    </div>
+    <div class="content">{$form.remote_registration_invitation_confirm_default_value.html}</div>
     <div class="clear"></div>
   </div>
 


### PR DESCRIPTION
This adds a general setting for *CiviRemote Event* for changing the pre-selected option for the *Confirm Invitation* field which is part of forms for participants with the status *Invited*.

Previously, there was no default value for this field, which, in the *CiviRemote Event* Drupal module, causes the pre-selected option to be "Decline Invitation" with all other fields of the form being hidden initially. This new option allows the pre-selected calue to be "Accept Invitation" and the entire form be displayed initially.

*systopia-reference: 26948*