### PR TITLE
Apply Smarty Security Policy and replace usage of `{crmAPI}` in affected templates

### DIFF
--- a/CRM/Remoteevent/EventSessions.php
+++ b/CRM/Remoteevent/EventSessions.php
@@ -763,6 +763,13 @@ class CRM_Remoteevent_EventSessions
      */
     protected static function renderSessionDescriptionLong($session)
     {
+        if (is_numeric($session['presenter_id'])) {
+            $session['presenter_display_name'] = \Civi\Api4\Contact::get(FALSE)
+                ->addSelect('display_name')
+                ->addWhere('id', '=', $session['presenter_id'])
+                ->execute()
+                ->single()['display_name'];
+        }
         return \Civi\RenderEvent::renderTemplate(
             E::path('resources/remote_session_description.tpl'),
             ['session' => $session],

--- a/CRM/Remoteevent/EventSessions.php
+++ b/CRM/Remoteevent/EventSessions.php
@@ -745,7 +745,7 @@ class CRM_Remoteevent_EventSessions
     {
         return \Civi\RenderEvent::renderTemplate(
             E::path('resources/remote_session_short_description.tpl'),
-            ['session' => $session],
+            ['eventSession' => $session],
             'remoteevent.session.description.short',
             'trim'
         );
@@ -772,7 +772,7 @@ class CRM_Remoteevent_EventSessions
         }
         return \Civi\RenderEvent::renderTemplate(
             E::path('resources/remote_session_description.tpl'),
-            ['session' => $session],
+            ['eventSession' => $session],
             'remoteevent.session.description.long',
             'trim'
         );

--- a/resources/remote_session_description.tpl
+++ b/resources/remote_session_description.tpl
@@ -25,7 +25,7 @@
   {if $session.presenter_id}
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-presenter {$style_odd}">
     <th>{if $session.presenter_title}{$session.presenter_title}{else}{ts}Presenter{/ts}{/if}</th>
-    <td>{crmAPI var='presenter' entity='Contact' action='getvalue' sequential=0 return="display_name" id=$session.presenter_id}{$presenter}</td>
+    <td>{$session.presenter_display_name}</td>
     {* swap following styles *}{assign var=style_odd value="even"}{assign var=style_even value="odd"}
   </tr>
   {/if}

--- a/resources/remote_session_description.tpl
+++ b/resources/remote_session_description.tpl
@@ -16,34 +16,34 @@
 <table class="civiremote-event-session-info">
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-title {$style_odd}">
     <th>{ts}Title{/ts}</th>
-    <td>{$session.title}</td>
+    <td>{$eventSession.title}</td>
   </tr>
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-restrictions {$style_even}">
     <th>{ts}Restrictions{/ts}</th>
-    <td>{if $session.max_participants}{ts 1=$session.max_participants}Up to %1 participants{/ts}{else}{ts}None{/ts}{/if}</td>
+    <td>{if $eventSession.max_participants}{ts 1=$eventSession.max_participants}Up to %1 participants{/ts}{else}{ts}None{/ts}{/if}</td>
   </tr>
-  {if $session.presenter_id}
+  {if $eventSession.presenter_id}
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-presenter {$style_odd}">
-    <th>{if $session.presenter_title}{$session.presenter_title}{else}{ts}Presenter{/ts}{/if}</th>
-    <td>{$session.presenter_display_name}</td>
+    <th>{if $eventSession.presenter_title}{$eventSession.presenter_title}{else}{ts}Presenter{/ts}{/if}</th>
+    <td>{$eventSession.presenter_display_name}</td>
     {* swap following styles *}{assign var=style_odd value="even"}{assign var=style_even value="odd"}
   </tr>
   {/if}
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-category {$style_odd}">
     <th>{ts}Category{/ts}</th>
-    <td>{$session.category}</td>
+    <td>{$eventSession.category}</td>
   </tr>
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-type {$style_even}">
     <th>{ts}Type{/ts}</th>
-    <td>{$session.type}</td>
+    <td>{$eventSession.type}</td>
   </tr>
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-location {$style_odd}">
     <th>{ts}Location{/ts}</th>
-    <td>{$session.location}</td>
+    <td>{$eventSession.location}</td>
   </tr>
   <tr class="civiremote-event-session-info-row civiremote-event-session-info-row-details {$style_even}">
     <th>{ts}Details{/ts}</th>
-    <td>{$session.description}</td>
+    <td>{$eventSession.description}</td>
   </tr>
 </table>
 {/crmScope}

--- a/resources/remote_session_short_description.tpl
+++ b/resources/remote_session_short_description.tpl
@@ -11,4 +11,4 @@
 | copyright header is strictly prohibited without        |
 | written permission from the original author(s).        |
 +--------------------------------------------------------+
-*}{crmScope extensionKey='de.systopia.remoteevent'}{ts}Category{/ts} {$session.category}, {ts}Type{/ts}: {$session.type}{if $session.location}, {ts}Location{/ts}: {$session.location}{/if}{/crmScope}
+*}{crmScope extensionKey='de.systopia.remoteevent'}{ts}Category{/ts} {$eventSession.category}, {ts}Type{/ts}: {$eventSession.type}{if $eventSession.location}, {ts}Location{/ts}: {$eventSession.location}{/if}{/crmScope}


### PR DESCRIPTION
The extension's utility method for rendering *Smarty* templates does not apply the Smarty User Content Policy introduced with CiviCRM `5.74.4` and `5.69.6`. Although rendering currently does not explicitly involve user content, it's safer to apply the policy and make default templates compatible by replacing usages of the `{crmAPI}` *Smarty* tag which is considered insecure by CiviCRM Core and thus causes an error with the policy applied.

There has been only one occurrence of the `{crmAPI}` *Smarty* tag in the extension's templates, which can be easily replaced by adding a template variable instead.

As which template is rendered is subject to Symfony event listener implementations, this PR should be included in a major (BC-breaking) or a minor version only with explicit documentation.