### PR TITLE
Standardize official extension name in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,95 @@
-# SYSTOPIA's Remote Event Extension
+# CiviRemote Event
+
 ## Scope
-This extension adds numerous features to CiviCRM's events. Specifically, it 
+
+This extension adds numerous features to CiviCRM's events. Specifically, it
 allows you to:
 + Configure events in CiviCRM
 + Display and use that information in other remote systems
 + Submit registrations for those events back to CiviCRM
 
-The main idea is that your organization's staff can handle all relevant event 
+The main idea is that your organization's staff can handle all relevant event
 configurations in CiviCRM. CiviCRM then makes this information available via its
-REST API. The extension's API also includes logic and actions to receive and 
+REST API. The extension's API also includes logic and actions to receive and
 update registrations.
 
-Any external system can interact with the API to display event calendars, 
+Any external system can interact with the API to display event calendars,
 detailed event information, registration forms, etc. This can be a remote system
-or the CMS your CiviCRM runs on. It can also submit information entered by your 
+or the CMS your CiviCRM runs on. It can also submit information entered by your
 constituents back to CiviCRM.
 
-To use these features, you must set up an external system to act as a frontend 
-for your event listings, registration forms, etc. If you plan to build your 
-system on Drupal 10, consider using the 
-[CiviRemote Drupal module](https://github.com/systopia/civiremote) which 
+To use these features, you must set up an external system to act as a frontend
+for your event listings, registration forms, etc. If you plan to build your
+system on Drupal 10, consider using the
+[CiviRemote Drupal module](https://github.com/systopia/civiremote) which
 includes many pre-built features.
 
-Note that this extension can be used alongside regular CiviCRM event 
-registrations. You can choose for each event whether to use the remote features 
+Note that this extension can be used alongside regular CiviCRM event
+registrations. You can choose for each event whether to use the remote features
 or not.
 
+
+
 ## Why this Extension?
+
 There are several scenarios where you might not want or be able to use CiviCRM's
 built-in forms, such as:
 + Your CiviCRM runs within a VPN for security reasons
-+ The built-in forms and processing logic do not offer enough customization 
++ The built-in forms and processing logic do not offer enough customization
 options
 + You already have an external system for your constituents (e.g., a member area
-on your website or a collaboration platform) that cannot be easily connected to 
+on your website or a collaboration platform) that cannot be easily connected to
 CiviCRM
 
 ## Features
-+ Connect a remote system to CiviCRM to handle highly customizable event 
+
++ Connect a remote system to CiviCRM to handle highly customizable event
 listings and registration features
-+ Pre-defined registration profiles, including a "one-click registration" for 
++ Pre-defined registration profiles, including a "one-click registration" for
 authenticated users
 + Use different registration profiles within the same event
 + Allow participants to modify or cancel their registrations
 + Alternative approach for defining an event's location
-+ Event registration/update profiles configurable using a UI with the [Remote 
++ Event registration/update profiles configurable using a UI with the [Remote
 Event Form Editor](https://github.com/systopia/remoteeventformeditor) extension
 + Manage sessions/workshops within your event
 + Register additional participants
-+ Localize event registration profiles with a locale specified in the get_form 
++ Localize event registration profiles with a locale specified in the get_form
 request (e.g., the current language of the frontend)
 
 ## Requirements
+
 + PHP v7.0+
 + CiviCRM 5.61
-+ Dependency on the CiviCRM Extension Remote Tools
++ Dependency on the CiviCRM Extension CiviRemote Tools
 + Dependency on the CiviCRM Extension Extended Contact Matcher
 + A system to serve as your public interface, such as an external website
 
 ## Extensions that Integrate with the Remote Event Extension
+
 + [Remote
-  Event Form Editor](https://github.com/systopia/remoteeventformeditor): 
+  Event Form Editor](https://github.com/systopia/remoteeventformeditor):
 A drag-and-drop form editor for event registration
 + [Event Invitations](https://github.com/systopia/de.systopia.eventinvitation)
 + [Custom Event Communication](https://github.com/systopia/de.systopia.eventmessages)
 + [Event-Checkin](https://github.com/systopia/de.systopia.eventcheckin)
 
 ## Documentation
+
 EN: https://docs.civicrm.org/remoteevent/en/latest (automatic publishing)
 
 ## We Need Your Support
-This CiviCRM extension is provided as Free and Open Source Software, and we are 
-happy if you find it useful. However, we have invested a lot of work into it 
-(and continue to do so), much of it unpaid. If you benefit from our software, 
-please consider making a financial contribution, so we can continue to maintain 
+
+This CiviCRM extension is provided as Free and Open Source Software, and we are
+happy if you find it useful. However, we have invested a lot of work into it
+(and continue to do so), much of it unpaid. If you benefit from our software,
+please consider making a financial contribution, so we can continue to maintain
 and develop it further.
 
-If you are willing to support us in developing this CiviCRM extension, please 
-email [info@systopia.de](mailto:info@systopia.de) to get an invoice or agree on 
+If you are willing to support us in developing this CiviCRM extension, please
+email [info@systopia.de](mailto:info@systopia.de) to get an invoice or agree on
 a different payment method.
 Thank you!
 
-This extension is licensed under 
+This extension is licensed under
 [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0).

--- a/README_DE.md
+++ b/README_DE.md
@@ -1,4 +1,4 @@
-# SYSTOPIAs Remote-Event-Erweiterung
+# CiviRemote Event
 
 ## Ziele und Funktionsumfang
 
@@ -29,6 +29,11 @@ enthält (https://github.com/systopia/civiremote).
 Beachten Sie, dass diese Erweiterung neben den regulären CiviCRM-Anmeldeseiten
 verwendet werden kann - Sie können für jedes Event wählen, ob Sie die
 Remote-Funktionen verwenden möchten oder nicht.
+
+Diese Erweiterung ist Teil des *CiviRemote*-Frameworks, das den Zugriff auf und
+die Interaktion mit CiviCRM-Entitäten über die REST-API für häufige
+Anwendungsfälle ermöglicht, indem Konfigurationsmöglichkeiten für die einfache
+Integration von entfernten Systemen bietet.
 
 ### Warum diese Erweiterung?
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
-## Remote Event API
+## CiviRemote Event API
 
-The extension exposes a new API to remote event listings or registration 
+The extension exposes a new API to remote event listings or registration
 systems:
 
 + ``RemoteEvent.get`` allows querying for remotely available events in the same

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,65 +1,65 @@
 ## Configuration
-After installing the extension, make sure your **Remote Tool settings** are 
-configured according to your needs (refer to the documentation provided in 
-[de.systopia.remotetools](https://github.com/systopia/de.systopia.remotetools)). 
+
+After installing the extension, make sure your **CiviRemote Tools settings** are
+configured according to your needs (refer to the documentation provided in
+[de.systopia.remotetools](https://github.com/systopia/de.systopia.remotetools)).
 Then proceed with the general configuration:
 
-* Navigate to >>Administer >>CiviEvent >>Remote Events - General Configuration 
-(/civicrm/admin/remoteevent/settings).
-* Define which participant status will block re-registration for your events 
+* Navigate to » *Administer* » *CiviEvent* » *CiviRemote Event - General Configuration* (`/civicrm/admin/remoteevent/settings`).
+* Define which participant status will block re-registration for your events
 (e.g., rejected) and specify which roles you want to assign to speakers.
 * Suppress workshop/session data if you do not use this feature.
 * Select the activity type for changes in participation data.
-* Configure the default matcher profile you would like to use (XCM-Extension). 
+* Configure the default matcher profile you would like to use (XCM-Extension).
 If using registration updates, ensure the XCM profile has the *Match contacts by
-contact ID* option activated to prevent duplicate contacts when updating event 
+contact ID* option activated to prevent duplicate contacts when updating event
 registrations.
 * Enter the URLs to be used for registrations, modifications, and cancellations,
-depending on the external system you use. If you use the CiviRemote Drupal 
+depending on the external system you use. If you use the CiviRemote Drupal
 module, you may use:
   - `https://yourdomain.org/civiremote/event/update/{token}`
   - `https://yourdomain.org/civiremote/event/cancel/{token}`
 
-After completing the general configuration, visit the new "Remote Online 
-Registration" tab within CiviCRM's event configuration UI. This tab provides 
-several options and settings under the "Online-Registration (CiviRemote)" and 
-"Workshops" sections. Notably, you can decide whether to use the remote event 
-features, disable native CiviCRM online registration, use alternative event 
+After completing the general configuration, visit the new "Remote Online
+Registration" tab within CiviCRM's event configuration UI. This tab provides
+several options and settings under the "Online-Registration (CiviRemote)" and
+"Workshops" sections. Notably, you can decide whether to use the remote event
+features, disable native CiviCRM online registration, use alternative event
 locations, or use external identification for your event.
 
-You will find two segments for registration profiles: one for initial 
-registration and another for editing registrations. The labels and help pop-ups 
+You will find two segments for registration profiles: one for initial
+registration and another for editing registrations. The labels and help pop-ups
 should provide sufficient information to understand your options.
 
-The "Registration Restrictions" section allows you to configure when 
+The "Registration Restrictions" section allows you to configure when
 registration is available, whether a registration requires manual review, and if
 participants can cancel or modify their own registrations.
 
 The "Additional Participants" feature allows you to add a group of people with a
-single registration. This results in a form where the participant can add up to 
-9 additional participants using increase/decrease buttons. For these additional 
-participants, a separate form can be selected to collect only names and email 
-addresses, while the main participant provides more information. You can also 
-select a specific XCM configuration for contact matching. In the participation 
+single registration. This results in a form where the participant can add up to
+9 additional participants using increase/decrease buttons. For these additional
+participants, a separate form can be selected to collect only names and email
+addresses, while the main participant provides more information. You can also
+select a specific XCM configuration for contact matching. In the participation
 overview, you can see who was added along with the main participant.
 
-The "Public Event Text Blocks" can be used by your external system to display 
-information at appropriate places during the registration process. How and when 
+The "Public Event Text Blocks" can be used by your external system to display
+information at appropriate places during the registration process. How and when
 this information is presented to your constituents depends on the design of your
 external system.
 
-CiviCRM's other basic event settings still apply and may be used in your 
-external system, including title, descriptions, start and end dates, 
+CiviCRM's other basic event settings still apply and may be used in your
+external system, including title, descriptions, start and end dates,
 maximum number of participants, waitlist settings, etc.
 
 ### Alternative Event Location Settings
 If the default event location feature is insufficient, you can choose to use the
-alternative event location feature. If you do, CiviCRM's regular event location 
-tab will be hidden, and a custom tab will appear. In this custom tab, you can 
-choose a contact with the subtype "event location" (the subtype is created when 
-installing the extension). You can also provide specific information for the 
+alternative event location feature. If you do, CiviCRM's regular event location
+tab will be hidden, and a custom tab will appear. In this custom tab, you can
+choose a contact with the subtype "event location" (the subtype is created when
+installing the extension). You can also provide specific information for the
 event location, such as room number or travel instructions.
 
-The API will then make the chosen event location's basic data available, 
+The API will then make the chosen event location's basic data available,
 including its name, address, geo data, and additional information for the event.
 This information can be displayed and used by the external system.


### PR DESCRIPTION
… and add a short paragraph about it being part of the *CiviRemote* Framework.