### PR TITLE
Add participants to waitlist if approval required

### DIFF
--- a/CRM/Remoteevent/Registration.php
+++ b/CRM/Remoteevent/Registration.php
@@ -668,14 +668,6 @@ class CRM_Remoteevent_Registration
         $participant_data = &$registration->getParticipantData();
         $event_data = $registration->getEvent();
 
-        // check if it registration requires approval
-        if (empty($participant_data['participant_status_id'])) {
-            if (!empty($event_data['requires_approval'])) {
-                // there is an active waiting list, see if need to get on it
-                $participant_data['participant_status_id'] = 'Awaiting approval';
-            }
-        }
-
         // check if this has a waiting list
         if (empty($participant_data['participant_status_id'])) {
             if (CRM_Remoteevent_RemoteEvent::hasActiveWaitingList($event_data['id'], $event_data)) {
@@ -686,6 +678,14 @@ class CRM_Remoteevent_Registration
                 } else {
                     $registration->addStatus(E::ts("You have been added to the waitlist."));
                 }
+            }
+        }
+
+        // check if it registration requires approval
+        if (empty($participant_data['participant_status_id'])) {
+            if (!empty($event_data['requires_approval'])) {
+                // there is an active waiting list, see if need to get on it
+                $participant_data['participant_status_id'] = 'Awaiting approval';
             }
         }
 


### PR DESCRIPTION
When approval is required for registrations, excess participants currently won't be given the `On Waitlist` status, effectively not using an active waitlist.

This PR adds participants to the waitlist regardless of whether approval is required. This matches core behavior. Participants on the waitlist are considered to require approval anyway. I consider this a bug, thus no configuration option for keeping the current behavior necessary, as there is no reduced functionality with this change.

*systopia-reference: 27449*