### PR TITLE
Include registrations with status class "Waiting" when checking for active waitlist

### DIFF
--- a/CRM/Remoteevent/RemoteEvent.php
+++ b/CRM/Remoteevent/RemoteEvent.php
@@ -248,7 +248,7 @@ class CRM_Remoteevent_RemoteEvent
             $registered_count = CRM_Remoteevent_Registration::getRegistrationCount(
                 $event_id,
                 NULL,
-                ['Positive', 'Pending']
+                ['Positive', 'Pending', 'Waiting']
             );
             return ($registered_count >= $event_data['max_participants']);
         } else {


### PR DESCRIPTION
Include participants with a status of class *Waiting* when calculating participant count for determining whether the waitlist is active (i.e. new participants will be added to the waitlist).

Without considering *Waiting* participants, and with *require approval* active, new registrations would get the *Requires Approval* status instead of being added to the waiting list, which should be the correct behavior as of #106 and #107.

This should be backported to `1.3` as well after merging.

*systopia-reference: 29733*