### PR TITLE
Use Core method for validating e-mail addresses

### DIFF
--- a/CRM/Remoteevent/RegistrationProfile.php
+++ b/CRM/Remoteevent/RegistrationProfile.php
@@ -615,7 +615,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
    * @phpstan-param array<string, array<string, mixed>> $field_spec
    *    specs, see getFields()
    *
-   * @param string $value
+   * @param string|null $value
    *    field value
    *
    * @return boolean
@@ -628,7 +628,9 @@ abstract class CRM_Remoteevent_RegistrationProfile {
     $validation = $field_spec['validation'] ?? '';
     switch ($validation) {
       case 'Email':
-        return preg_match('#^([a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,5})$#', $value) > 0;
+        // Since CiviCRM Core uses \CRM_Utils_Rule::email() for validating e-mail addresses, we rely on it here.
+        // \CRM_Utils_Rule::email() returns TRUE for unset or empty values, therefore require a value here.
+        return NULL !== $value && '' !== $value && \CRM_Utils_Rule::email($value);
 
       case 'Integer':
       case 'Int':
@@ -654,7 +656,7 @@ abstract class CRM_Remoteevent_RegistrationProfile {
       default:
         // check for regex
         if (substr($validation, 0, 6) == 'regex:') {
-          if (strlen($value) > 0) {
+          if (NULL !== $value && strlen($value) > 0) {
             return preg_match(substr($validation, 6), $value) > 0;
           }
           else {


### PR DESCRIPTION
*systopia-reference: 30435*

Use `\CRM_Utils_Rule::email()` for validating e-mail fields, as CiviCRM Core uses that method for validating e-mail addresses thoughout, although the used mechanism relies on PHP's `filter_var()` with `FILTER_VALIDATE_EMAIL` which apparently is not fully compliant with RFC5321.

The regular expression currently in use in *CiviRemote Event* is much simpler and stricter and does not allow TLD names longer than 5 characters, which seems rather arbitrary and excludes totally valid ones like `.hamburg` etc. - see the [Wikipedia list of TLDs](https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains).

We should consider backporting this for the `1.3` branch.