### PR TITLE
Fix `meta` permissions in `RemoteEventMailingList`

### DIFF
--- a/Civi/Api4/RemoteEventMailingList.php
+++ b/Civi/Api4/RemoteEventMailingList.php
@@ -34,11 +34,14 @@ final class RemoteEventMailingList extends AbstractEntity {
     return new BasicGetFieldsAction(self::getEntityName(), __FUNCTION__, fn () => []);
   }
 
+  /**
+   * @return array<string, array<string|array<string>>>
+   */
   public static function permissions(): array {
-      return [
-        'meta' => ['register to Remote Events'],
-        'default' => ['register to Remote Events'],
-      ];
-    }
+    return [
+      'meta' => ['access CiviCRM'],
+      'default' => ['register to Remote Events'],
+    ];
+  }
 
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,6 +23,7 @@
         <!-- Conflicts with PHPStan type hints -->
         <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
         <exclude name="Drupal.Commenting.FunctionComment.ParamTypeSpaces"/>
+        <exclude name="Drupal.Commenting.FunctionComment.ReturnTypeSpaces"/>
 
         <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
         <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>


### PR DESCRIPTION
The permission for `meta` actions should be set to `access CiviCRM` to avoid a `\Civi\API\Exception\UnauthorizedException` when calling the `getActions` action.

systopia-reference: 30501