### PR TITLE
Update workflows for phpstan and phpunit and the phpstan baseline

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,12 @@
 name: PHPStan
 
 on:
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      civicrm-version:
+        description: 'CiviCRM version constraint'
+        required: false
+        type: string
   pull_request:
     paths:
       - '**.php'
@@ -11,10 +16,15 @@ on:
       - phpstan.neon.dist
       - .github/workflows/phpstan.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.civicrm-version }}
+  cancel-in-progress: true
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.4']
         prefer: ['prefer-stable', 'prefer-lowest']
@@ -56,16 +66,29 @@ jobs:
         composer config --no-plugins allow-plugins.composer/installers true
         composer config --no-plugins allow-plugins.cweagans/composer-patches true
 
+        composer config --json "extra.installer-paths.$(dirname $PWD)/{\$name}" '["type:civicrm-ext"]'
+        composer require --ignore-platform-reqs --no-progress composer/installers
+
+        if [ -n "${{ inputs.civicrm-version }}" ]; then
+          composer require --no-update "civicrm/civicrm-core:${{ inputs.civicrm-version }}" \
+            "civicrm/civicrm-packages:${{ inputs.civicrm-version }}"
+        fi
+
+        # Until systopia/de.systopia.remotetools is officially released as composer package.
+        git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
+        composer config repositories.remotetools path $(dirname $PWD)/de.systopia.remotetools
+        composer require --no-update systopia/de.systopia.remotetools
+
+        composer suggests --list | xargs -r composer require --no-update --${{ matrix.prefer }} --ignore-platform-reqs
+
+        git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider
+        git clone --depth=1 https://github.com/systopia/de.systopia.xportx.git ../de.systopia.xportx
+
         # Run with --no-scripts so ComposerHelper doesn't prevent installation
         # of civicrm packages.
-        git clone --depth=1 https://lab.civicrm.org/extensions/action-provider.git ../action-provider
-        git clone --depth=1 https://github.com/systopia/de.systopia.eventmessages.git ../de.systopia.eventmessages
-        git clone --depth=1 https://github.com/systopia/de.systopia.xcm.git ../de.systopia.xcm
-        git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
-        git clone --depth=1 https://github.com/systopia/de.systopia.xportx.git ../de.systopia.xportx
-        composer update --no-scripts --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader --ignore-platform-reqs
-        composer composer-phpunit -- update --no-progress --prefer-dist --optimize-autoloader
-        composer composer-phpstan -- update --no-progress --prefer-dist --optimize-autoloader
+        composer update --no-scripts --no-progress --${{ matrix.prefer }} --optimize-autoloader --ignore-platform-reqs
+        composer composer-phpunit -- update --no-progress --optimize-autoloader
+        composer composer-phpstan -- update --no-progress --optimize-autoloader
 
     - name: Run PHPStan
       run: composer phpstan -- analyse -c phpstan.ci.neon

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,7 @@ jobs:
   phpunit:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.4']
         prefer: ['prefer-stable', 'prefer-lowest']
@@ -78,7 +78,7 @@ jobs:
 
         EXT_DIR=$PWD
         EXT_COMPOSER_NAME=$(composer show --self --name-only)
-        composer composer-phpunit -- update --no-progress --prefer-dist --optimize-autoloader
+        composer composer-phpunit -- update --no-progress --optimize-autoloader
         cd ..
         git clone https://github.com/civicrm/civicrm-standalone.git
         cd civicrm-standalone
@@ -90,18 +90,23 @@ jobs:
 
         # Use civicrm-core and civicrm-packages defined in extension's composer.json.
         composer remove --no-update civicrm/civicrm-core civicrm/civicrm-packages
-        composer require composer/installers civicrm/cli-tools
+        composer require --no-progress composer/installers civicrm/cli-tools
         if [ -n "${{ inputs.civicrm-version }}" ]; then
           composer require --no-update "civicrm/civicrm-core:${{ inputs.civicrm-version }}" \
             "civicrm/civicrm-packages:${{ inputs.civicrm-version }}"
         fi
+
+        # Until systopia/de.systopia.remotetools is officially released as composer package.
+        git clone --depth=1 https://github.com/systopia/de.systopia.remotetools.git ../de.systopia.remotetools
+        composer config repositories.remotetools path $(dirname $PWD)/de.systopia.remotetools
+        composer require --no-update systopia/de.systopia.remotetools
 
         # --with-all-dependencies is required because downgrades from packages
         # installed before might be necessary.
         # \PEAR_ErrorStack::singleton() is static since pear/pear-core v1.10.16
         # civicrm/composer-compile-plugin v0.22 is the minimum version
         # compatible with symfony/console >=8.0 used in composer since 2.9.0.
-        composer require --with-all-dependencies --no-progress --prefer-dist --${{ matrix.prefer }} \
+        composer require --with-all-dependencies --no-progress --${{ matrix.prefer }} \
           --optimize-autoloader $EXT_COMPOSER_NAME 'pear/pear-core-minimal:>=1.10.16' \
           'civicrm/composer-compile-plugin:>=0.22'
 
@@ -123,10 +128,6 @@ jobs:
         sed -i "s#\"TEST_DB_DSN\": \".*\"#\"TEST_DB_DSN\": \"$DATABASE_URL\"#g" "$CV_CONFIG"
 
         cv ext:download "action-provider@https://lab.civicrm.org/extensions/action-provider/-/archive/1.193/action-provider-1.193.zip"
-        cv ext:download "de.systopia.xcm@https://github.com/systopia/de.systopia.xcm/releases/download/1.14.1/de.systopia.xcm-1.14.1.zip"
-        cv ext:download "de.systopia.identitytracker@https://github.com/systopia/de.systopia.identitytracker/releases/download/1.4.0/de.systopia.identitytracker-1.4.0.zip"
-        cv ext:download "de.systopia.remotetools@https://github.com/systopia/de.systopia.remotetools/releases/download/1.1.0/de.systopia.remotetools-1.1.0.zip"
-        cv ext:download "de.systopia.remotetools@https://github.com/systopia/de.systopia.xportx/releases/download/0.8.0/de.systopia.xportx-0.8.0.zip"
 
     - name: Run PHPUnit
       run: |

--- a/ComposerHelper.php
+++ b/ComposerHelper.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Remoteevent;
 
 use Composer\Package\Link;
-use Composer\Repository\RepositoryManager;
 use Composer\Script\Event;
 
 final class ComposerHelper {

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,11 @@
     },
     "require": {
         "php": "^8.1",
-        "civicrm/civicrm-core": ">=5.76",
-        "civicrm/civicrm-packages": ">=5.76"
+        "civicrm/civicrm-core": ">=6.2",
+        "civicrm/civicrm-packages": ">=6.2"
+    },
+    "suggest": {
+        "systopia/de.systopia.eventmessages": "Send emails to participants"
     },
     "autoload": {
         "classmap": ["ComposerHelper.php"]

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.4.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.76</ver>
+    <ver>6.2</ver>
   </compatibility>
   <comments/>
   <requires>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -295,10 +295,40 @@ parameters:
 			path: CRM/Remoteevent/ChangeActivity.php
 
 		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: CRM/Remoteevent/ChangeActivity.php
+
+		-
 			message: '#^Property CRM_Remoteevent_ChangeActivity\:\:\$record_stack type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: CRM/Remoteevent/ChangeActivity.php
+
+		-
+			message: '#^Parameter \#1 \$entity_type of method CRM_Remoteevent_CustomData\:\:createEntity\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: CRM/Remoteevent/CustomData.php
+
+		-
+			message: '#^Parameter \#1 \$entity_type of method CRM_Remoteevent_CustomData\:\:identifyEntity\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: CRM/Remoteevent/CustomData.php
+
+		-
+			message: '#^Parameter \#1 \$entity_type of method CRM_Remoteevent_CustomData\:\:updateEntity\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: CRM/Remoteevent/CustomData.php
+
+		-
+			message: '#^Part \$data\[''entity''\] \(mixed\) of encapsed string cannot be cast to string\.$#'
+			identifier: encapsedStringPart.nonString
+			count: 1
+			path: CRM/Remoteevent/CustomData.php
 
 		-
 			message: '#^Cannot access offset ''values'' on array\|int\.$#'
@@ -1876,6 +1906,12 @@ parameters:
 			path: CRM/Remoteevent/Page/SessionParticipantList.php
 
 		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<mixed, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: CRM/Remoteevent/Page/SessionParticipantList.php
+
+		-
 			message: '#^Access to an undefined property object\:\:\$contact_id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -2844,6 +2880,12 @@ parameters:
 			message: '#^Only booleans are allowed in an if condition, mixed given\.$#'
 			identifier: if.condNotBoolean
 			count: 2
+			path: CRM/Remoteevent/RemoteEvent.php
+
+		-
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<int, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
 			path: CRM/Remoteevent/RemoteEvent.php
 
 		-

--- a/phpstan.ci.neon
+++ b/phpstan.ci.neon
@@ -3,11 +3,11 @@ includes:
 
 parameters:
 	scanDirectories:
-		- vendor/civicrm/civicrm-core/api/
-		- vendor/civicrm/civicrm-core/CRM/
-		- vendor/civicrm/civicrm-core/Civi/
-		- vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
-		- vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
+		- vendor/civicrm/civicrm-core/api
+		- vendor/civicrm/civicrm-core/CRM
+		- vendor/civicrm/civicrm-core/Civi
+		- vendor/civicrm/civicrm-core/ext/civi_event/Civi/Api4
+		- vendor/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4
 		- vendor/civicrm/civicrm-core/ext/legacycustomsearches/CRM
 		- vendor/civicrm/civicrm-packages/HTML
 		- vendor/civicrm/civicrm-packages/DB

--- a/phpstan.neon.template
+++ b/phpstan.neon.template
@@ -6,11 +6,11 @@ includes:
 
 parameters:
 	scanDirectories:
-		- {VENDOR_DIR}/civicrm/civicrm-core/api/
-		- {VENDOR_DIR}/civicrm/civicrm-core/CRM/
-		- {VENDOR_DIR}/civicrm/civicrm-core/Civi/
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4/
-		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4/
+		- {VENDOR_DIR}/civicrm/civicrm-core/api
+		- {VENDOR_DIR}/civicrm/civicrm-core/CRM
+		- {VENDOR_DIR}/civicrm/civicrm-core/Civi
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_event/Civi/Api4
+		- {VENDOR_DIR}/civicrm/civicrm-core/ext/civi_contribute/Civi/Api4
 		- {VENDOR_DIR}/civicrm/civicrm-core/ext/legacycustomsearches/CRM
 		- {VENDOR_DIR}/civicrm/civicrm-packages/HTML
 		- {VENDOR_DIR}/civicrm/civicrm-packages/DB
@@ -22,6 +22,13 @@ parameters:
 #
 #parameters:
 #	scanDirectories:
+#		- {CIVICRM_DIR}/api
 #		- {CIVICRM_DIR}/CRM
+#		- {CIVICRM_DIR}/Civi
+#		- {CIVICRM_DIR}/ext/civi_event/Civi/Api4
+#		- {CIVICRM_DIR}/ext/civi_contribute/Civi/Api4
+#		- {CIVICRM_DIR}/ext/legacycustomsearches/CRM
+#		- {CIVICRM_DIR}/packages/HTML
+#		- {CIVICRM_DIR}/packages/DB
 #	bootstrapFiles:
 #		- {CIVICRM_DIR}/vendor/autoload.php

--- a/tools/update-pot.sh
+++ b/tools/update-pot.sh
@@ -20,7 +20,7 @@ EOD
 
 if [ $# -eq 1 ]; then
   usage
-  if [ $1 = -h ] || [ $1 = --help ]; then
+  if [ "$1" = -h ] || [ "$1" = --help ]; then
     exit
   fi
   exit 1


### PR DESCRIPTION
CiviCRM extensions are now installed as composer package in the GitHub workflows, if possible.

Note: The previous phpunit workflow contained `cv ext:download "de.systopia.remotetools@https://github.com/systopia/de.systopia.xportx/releases/download/0.8.0/de.systopia.xportx-0.8.0.zip"`, though due to the wrong extension ID it wasn't installed. It's not required to run the tests and in the current state the installation fails anyway (`civix upgrade` requried):
> In xportx.civix.php line 259:
> syntax error, unexpected token "{"

The update in the phpstan baseline are required because of changes in phpstan.

systopia-reference: 29954