### PR TITLE
Fix participant session tokens

### DIFF
--- a/CRM/Remoteevent/BAO/Session.php
+++ b/CRM/Remoteevent/BAO/Session.php
@@ -15,23 +15,46 @@
 
 declare(strict_types = 1);
 
+use Civi\Api4\Session;
 use CRM_Remoteevent_ExtensionUtil as E;
 
 /**
  * @phpstan-type sessionT array{
  *     id: int,
- *     event_id: string,
- *     type_id: string,
- *     category_id: string,
+ *     event_id: int,
+ *     title: string,
+ *     description: string|null,
+ *     slot_id: int|null,
+ *     type_id: int|null,
+ *     category_id: int|null,
  *     start_date: string,
  *     end_date: string,
+ *     max_participants: int|null,
+ *     location: string|null,
+ *   }
+ *
+ * @phpstan-type sessionWithDayT array{
+ *     id: int,
+ *     event_id: int,
+ *     title: string,
+ *     description: string|null,
+ *     slot_id: int|null,
+ *     type_id: int|null,
+ *     category_id: int|null,
+ *     start_date: string,
+ *     end_date: string,
+ *     max_participants: int|null,
+ *     location: string|null,
+ *     day: int,
  *   }
  */
 class CRM_Remoteevent_BAO_Session extends CRM_Remoteevent_DAO_Session {
 
   /**
-   * @var array cached session data by event_id */
-  protected static $session_cache = [];
+   * @phpstan-var array<int, array<int, sessionWithDayT>>
+   *   cached session data by event_id
+   */
+  protected static array $sessionCache = [];
 
   /**
    * Create a new Session based on array-data
@@ -126,103 +149,50 @@ class CRM_Remoteevent_BAO_Session extends CRM_Remoteevent_DAO_Session {
   /**
    * Cache the given sessions to be queried with getSessions
    *
-   * @param array $event_ids
-   *  event IDs
+   * @param list<int> $eventIds
+   *   Event IDs
+   * @param array<int, array<string, mixed>> $eventData
+   *   Event data by event ID.
    */
-  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
-  public static function cacheSessions($event_ids, $event_data) {
-    // make sure there are no bogous IDs
-    $event_ids = array_map('intval', $event_ids);
-    if (empty($event_ids)) {
-      return;
-    }
-
-    // this is what we want to collect and cache
-    $session_list_by_event = [];
-
-    // now load all sessions
-    /** @phpstan-var array{values: array<int, sessionT>} $sessionsResult */
-    $sessionsResult = civicrm_api3('Session', 'get', [
-      'event_id'     => ['IN' => $event_ids],
-      'option.limit' => 0,
-      'option.sort'  => 'start_date asc, id asc',
-    ]);
-
-    // sort all sessions into the events
-    foreach ($sessionsResult['values'] as $session) {
-      // detached session? skip!
-      if (empty($session['event_id'])) {
-        continue;
-      }
-
-      // get the event start date, so we can the session day
-      if (isset($event_data[$session['event_id']]['start_date'])) {
-        $event_start_date = strtotime($event_data[$session['event_id']]['start_date']);
+  public static function cacheSessions(array $eventIds, array $eventData): void {
+    foreach ($eventIds as $eventId) {
+      if (is_string($eventData[$eventId]['start_date'] ?? NULL)) {
+        $eventStartDate = $eventData[$eventId]['start_date'];
       }
       else {
-        Civi::log()->debug(
-          // phpcs:ignore Generic.Files.LineLength.TooLong
-          'CRM_Remoteevent_BAO_Session:cacheSessions separately loading event start dates. This should not happen, and is very slow.'
-        );
-        $event_start_date = strtotime(
-          civicrm_api3('Event', 'getvalue', ['return' => 'start_date', 'id' => $session['event_id']])
-        );
+        $eventStartDate = NULL;
       }
-
-      // calculate day of event
-      $sessionStartDate = strtotime($session['start_date']);
-      if (FALSE === $sessionStartDate) {
-        throw new \RuntimeException('Invalid session start date.');
-      }
-      $session['day'] = 1 + (int) (($sessionStartDate - $event_start_date) / (60 * 60 * 24));
-
-      if (is_numeric($session['type_id'] ?? NULL)) {
-        $session['type_id'] = (int) $session['type_id'];
-      }
-      if (is_numeric($session['category_id'] ?? NULL)) {
-        $session['category_id'] = (int) $session['category_id'];
-      }
-      if (is_numeric($session['slot_id'] ?? NULL)) {
-        $session['slot_id'] = (int) $session['slot_id'];
-      }
-
-      // store
-      $session_list_by_event[$session['event_id']][$session['id']] = $session;
-    }
-
-    // cache
-    foreach ($session_list_by_event as $event_id => $session_list) {
-      self::$session_cache[$event_id] = $session_list;
+      self::getSessions($eventId, FALSE, $eventStartDate);
     }
   }
 
   /**
-   * Get a list of sessions as property arrays,
-   *  ordered by start_date,
-   *  with additional attributes such as
-   *   'day': number of day (1 = first, 2 = second, ...)
+   * Get a list of sessions indexed by ID, ordered by start_date, with one
+   * additional attribute:
+   * 'day': The number of the event day, when the session starts. (1 = first day
+   *   of event, 2 = second day of event, ...)
    *
-   * @param integer $event_id
+   * @param int $eventId
    *  event ID
-   *
-   * @param boolean $cached
+   * @param bool $cached
    *  use a cached result, or reload (and refresh cache)
-   *
-   * @param string $start_date
+   * @param string|null $eventStartDate
    *  event start_date. if empty, will be loaded from the event
+   *
+   * @phpstan-return array<int, sessionWithDayT>
    */
-  // phpcs:ignore Generic.Metrics.CyclomaticComplexity.TooHigh
-  public static function getSessions($event_id, $cached = TRUE, $start_date = NULL) {
-    $event_id = (int) $event_id;
-    if ($cached && isset(self::$session_cache[$event_id])) {
-      return self::$session_cache[$event_id];
+  public static function getSessions($eventId, bool $cached = TRUE, ?string $eventStartDate = NULL): array {
+    $eventId = (int) $eventId;
+    if ($cached && isset(self::$sessionCache[$eventId])) {
+      return self::$sessionCache[$eventId];
     }
 
     // first: get the start date if it's not passed
-    if (empty($start_date)) {
+    if (empty($eventStartDate)) {
       try {
-        $start_date = civicrm_api3('Event', 'getvalue', [
-          'id'     => $event_id,
+        /** @var string $eventStartDate */
+        $eventStartDate = civicrm_api3('Event', 'getvalue', [
+          'id'     => $eventId,
           'return' => 'start_date',
         ]);
       }
@@ -231,43 +201,28 @@ class CRM_Remoteevent_BAO_Session extends CRM_Remoteevent_DAO_Session {
         return [];
       }
     }
-    $start_day = strtotime(substr($start_date, 0, 10));
 
     // now load all sessions
-    $session_list = [];
-    /** @phpstan-var array{values: array<int, sessionT>} $sessionsResult */
-    $sessionsResult = civicrm_api3('Session', 'get', [
-      'event_id'     => $event_id,
-      'option.limit' => 0,
-      'option.sort'  => 'start_date asc, id asc',
-    ]);
+    /** @phpstan-var array<int, sessionT> $sessions */
+    $sessions = Session::get(FALSE)
+      ->addWhere('event_id', '=', $eventId)
+      ->addWhere('start_date', 'IS NOT NULL')
+      ->addWhere('end_date', 'IS NOT NULL')
+      ->addWhere('title', 'IS NOT NULL')
+      ->addOrderBy('start_date')
+      ->addOrderBy('id')
+      ->execute()
+      ->indexBy('id')
+      ->getArrayCopy();
 
-    foreach ($sessionsResult['values'] as $session) {
-      // calculate day of event
-      $session_day = strtotime(substr($session['start_date'], 0, 10));
-      if (FALSE === $session_day) {
-        throw new \RuntimeException('Invalid session start date.');
-      }
-      $session['day'] = 1 + (int) (($session_day - $start_day) / (60 * 60 * 24));
-
-      if (is_numeric($session['type_id'] ?? NULL)) {
-        $session['type_id'] = (int) $session['type_id'];
-      }
-      if (is_numeric($session['category_id'] ?? NULL)) {
-        $session['category_id'] = (int) $session['category_id'];
-      }
-      if (is_numeric($session['slot_id'] ?? NULL)) {
-        $session['slot_id'] = (int) $session['slot_id'];
-      }
-
-      // store
-      $session_list[(int) $session['id']] = $session;
+    foreach ($sessions as &$session) {
+      $session['day'] = self::calcSessionDay($session['start_date'], $eventStartDate);
     }
 
     // cache
-    self::$session_cache[$event_id] = $session_list;
+    self::$sessionCache[$eventId] = $sessions;
 
-    return $session_list;
+    return $sessions;
   }
 
   /**
@@ -469,14 +424,19 @@ class CRM_Remoteevent_BAO_Session extends CRM_Remoteevent_DAO_Session {
   /**
    * Get the label of the session category
    *
-   * @param integer $slot_id
+   * @param integer|null $slot_id
    *   the slot id
    *
    * @return string
    *   resolved label
    */
-  public static function getSlotLabel($slot_id) {
+  public static function getSlotLabel(?int $slot_id): string {
     $noneLabel = E::ts('None');
+
+    if (NULL === $slot_id) {
+      return $noneLabel;
+    }
+
     // gather types
     static $slots = NULL;
     if ($slots === NULL) {
@@ -494,6 +454,22 @@ class CRM_Remoteevent_BAO_Session extends CRM_Remoteevent_DAO_Session {
 
     // resolve
     return $slots[$slot_id] ?? $noneLabel;
+  }
+
+  /**
+   * @return int
+   *   The number of the event day, when the session starts.
+   *   (1 = first day of event, 2 = second day of event, ...)
+   */
+  private static function calcSessionDay(string $sessionStartDate, string $eventStartDate): int {
+    $sessionStartDate = (new \DateTime($sessionStartDate))->setTime(0, 0);
+    $eventEndDate = (new \DateTime($eventStartDate))->setTime(0, 0);
+    $diff = $sessionStartDate->diff($eventEndDate);
+    if (!is_int($diff->days)) {
+      throw new \InvalidArgumentException('Calculating date diff failed');
+    }
+
+    return $diff->days + 1;
   }
 
 }

--- a/CRM/Remoteevent/EventSessions.php
+++ b/CRM/Remoteevent/EventSessions.php
@@ -123,14 +123,14 @@ class CRM_Remoteevent_EventSessions {
             [
               'name' => 'slot',
               'type' => CRM_Utils_Type::T_STRING,
-              'value' => CRM_Remoteevent_BAO_Session::getSlotLabel($session['slot_id'] ?? NULL),
+              'value' => CRM_Remoteevent_BAO_Session::getSlotLabel($session['slot_id']),
               'title' => E::ts('Slot'),
               'localizable' => 1,
             ],
             [
               'name' => 'category',
               'type' => CRM_Utils_Type::T_STRING,
-              'value' => CRM_Remoteevent_BAO_Session::getSessionCategoryLabel($session['category_id'] ?? NULL),
+              'value' => CRM_Remoteevent_BAO_Session::getSessionCategoryLabel($session['category_id']),
               'title' => E::ts('Category'),
               'localizable' => 1,
             ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -63,25 +63,7 @@ parameters:
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 6
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Method CRM_Remoteevent_BAO_Session\:\:cacheSessions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Method CRM_Remoteevent_BAO_Session\:\:cacheSessions\(\) has parameter \$event_data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Method CRM_Remoteevent_BAO_Session\:\:cacheSessions\(\) has parameter \$event_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
+			count: 4
 			path: CRM/Remoteevent/BAO/Session.php
 
 		-
@@ -127,12 +109,6 @@ parameters:
 			path: CRM/Remoteevent/BAO/Session.php
 
 		-
-			message: '#^Method CRM_Remoteevent_BAO_Session\:\:getSessions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
 			message: '#^Method CRM_Remoteevent_BAO_Session\:\:setParticipantRegistrations\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -151,32 +127,14 @@ parameters:
 			path: CRM/Remoteevent/BAO/Session.php
 
 		-
-			message: '#^Only numeric types are allowed in \-, int\|false given on the right side\.$#'
-			identifier: minus.rightNonNumeric
-			count: 2
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Parameter \#1 \$datetime of function strtotime expects string, array\|int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Parameter \#1 \$string of function substr expects string, array\|int\|string given\.$#'
-			identifier: argument.type
+			message: '#^PHPDoc tag @var with type string is not subtype of type array\|int\.$#'
+			identifier: varTag.type
 			count: 1
 			path: CRM/Remoteevent/BAO/Session.php
 
 		-
 			message: '#^Parameter \#3 \$objectId of static method CRM_Utils_Hook\:\:post\(\) expects int, int\|string\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: CRM/Remoteevent/BAO/Session.php
-
-		-
-			message: '#^Property CRM_Remoteevent_BAO_Session\:\:\$session_cache type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: CRM/Remoteevent/BAO/Session.php
 
@@ -967,9 +925,9 @@ parameters:
 			path: CRM/Remoteevent/EventSessions.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, \(int\|string\) given\.$#'
+			message: '#^Only booleans are allowed in an if condition, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
 			identifier: if.condNotBoolean
-			count: 1
+			count: 2
 			path: CRM/Remoteevent/EventSessions.php
 
 		-
@@ -979,14 +937,14 @@ parameters:
 			path: CRM/Remoteevent/EventSessions.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, int\|string given\.$#'
+			message: '#^Only booleans are allowed in an if condition, string given\.$#'
 			identifier: if.condNotBoolean
 			count: 1
 			path: CRM/Remoteevent/EventSessions.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, string given\.$#'
-			identifier: if.condNotBoolean
+			message: '#^Parameter \#1 \$eventId of static method CRM_Remoteevent_BAO_Session\:\:getSessions\(\) expects int, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: CRM/Remoteevent/EventSessions.php
 
@@ -997,13 +955,7 @@ parameters:
 			path: CRM/Remoteevent/EventSessions.php
 
 		-
-			message: '#^Parameter \#1 \$event_id of static method CRM_Remoteevent_BAO_Session\:\:getSessions\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: CRM/Remoteevent/EventSessions.php
-
-		-
-			message: '#^Parameter \#3 \$start_date of static method CRM_Remoteevent_BAO_Session\:\:getSessions\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$eventStartDate of static method CRM_Remoteevent_BAO_Session\:\:getSessions\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: CRM/Remoteevent/EventSessions.php
@@ -1273,6 +1225,18 @@ parameters:
 			path: CRM/Remoteevent/Form/EventSessions.php
 
 		-
+			message: '#^Only numeric types are allowed in \-, int\|false given on the left side\.$#'
+			identifier: minus.leftNonNumeric
+			count: 1
+			path: CRM/Remoteevent/Form/EventSessions.php
+
+		-
+			message: '#^Only numeric types are allowed in \-, int\|false given on the right side\.$#'
+			identifier: minus.rightNonNumeric
+			count: 1
+			path: CRM/Remoteevent/Form/EventSessions.php
+
+		-
 			message: '#^Parameter \#1 \$event of static method CRM_Remoteevent_EventSessions\:\:getSessionWarnings\(\) expects array, array\|int given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1299,14 +1263,8 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$timestamp of function date expects int\|null, int\|false given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 5
 			path: CRM/Remoteevent/Form/EventSessions.php
-
-		-
-			message: '#^Argument of an invalid type array\|null supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: CRM/Remoteevent/Form/ParticipantSessions.php
 
 		-
 			message: '#^BooleanAnd\: Condition between true and false are always false\.$#'

--- a/tests/phpunit/CRM/Remoteevent/BAO/SessionTest.php
+++ b/tests/phpunit/CRM/Remoteevent/BAO/SessionTest.php
@@ -1,0 +1,156 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+use Civi\RemoteEvent\AbstractRemoteEventHeadlessTestCase;
+use Civi\RemoteEvent\Fixtures\RemoteEventFixture;
+use Civi\RemoteEvent\Fixtures\SessionFixture;
+
+/**
+ * @covers \CRM_Remoteevent_BAO_Session
+ *
+ * @group headless
+ */
+final class CRM_Remoteevent_BAO_SessionTest extends AbstractRemoteEventHeadlessTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+  }
+
+  public function testGetSessions(): void {
+    $event1 = RemoteEventFixture::addFixture(['start_date' => '2026-04-16']);
+    $event2 = RemoteEventFixture::addFixture(['start_date' => '2026-04-17']);
+
+    $session1_1 = SessionFixture::addFixture($event1['id'], [
+      'title' => 'Event 1 Session 1',
+      'start_date' => '2026-04-18 12:00:00',
+      'end_date' => '2026-04-18 14:00:00',
+    ]);
+    static::assertSame([
+      $session1_1['id'] => [
+        'id' => $session1_1['id'],
+        'event_id' => $event1['id'],
+        'title' => 'Event 1 Session 1',
+        'is_active' => TRUE,
+        'start_date' => '2026-04-18 12:00:00',
+        'end_date' => '2026-04-18 14:00:00',
+        'slot_id' => NULL,
+        'category_id' => NULL,
+        'type_id' => NULL,
+        'description' => NULL,
+        'max_participants' => 0,
+        'location' => NULL,
+        'presenter_id' => NULL,
+        'presenter_title' => NULL,
+        'day' => 3,
+      ],
+    ], CRM_Remoteevent_BAO_Session::getSessions($event1['id']));
+
+    $session1_2 = SessionFixture::addFixture($event1['id'], [
+      'title' => 'Event 1 Session 2',
+      'start_date' => '2026-04-16 10:00:00',
+      'end_date' => '2026-04-18 14:00:00',
+    ]);
+
+    // Cached result is returned.
+    static::assertSame([
+      $session1_1['id'] => [
+        'id' => $session1_1['id'],
+        'event_id' => $event1['id'],
+        'title' => 'Event 1 Session 1',
+        'is_active' => TRUE,
+        'start_date' => '2026-04-18 12:00:00',
+        'end_date' => '2026-04-18 14:00:00',
+        'slot_id' => NULL,
+        'category_id' => NULL,
+        'type_id' => NULL,
+        'description' => NULL,
+        'max_participants' => 0,
+        'location' => NULL,
+        'presenter_id' => NULL,
+        'presenter_title' => NULL,
+        'day' => 3,
+      ],
+    ], CRM_Remoteevent_BAO_Session::getSessions($event1['id']));
+
+    static::assertSame([
+      $session1_2['id'] => [
+        'id' => $session1_2['id'],
+        'event_id' => $event1['id'],
+        'title' => 'Event 1 Session 2',
+        'is_active' => TRUE,
+        'start_date' => '2026-04-16 10:00:00',
+        'end_date' => '2026-04-18 14:00:00',
+        'slot_id' => NULL,
+        'category_id' => NULL,
+        'type_id' => NULL,
+        'description' => NULL,
+        'max_participants' => 0,
+        'location' => NULL,
+        'presenter_id' => NULL,
+        'presenter_title' => NULL,
+        'day' => 1,
+      ],
+      $session1_1['id'] => [
+        'id' => $session1_1['id'],
+        'event_id' => $event1['id'],
+        'title' => 'Event 1 Session 1',
+        'is_active' => TRUE,
+        'start_date' => '2026-04-18 12:00:00',
+        'end_date' => '2026-04-18 14:00:00',
+        'slot_id' => NULL,
+        'category_id' => NULL,
+        'type_id' => NULL,
+        'description' => NULL,
+        'max_participants' => 0,
+        'location' => NULL,
+        'presenter_id' => NULL,
+        'presenter_title' => NULL,
+        'day' => 3,
+      ],
+    ], CRM_Remoteevent_BAO_Session::getSessions($event1['id'], FALSE));
+
+    static::assertSame([], CRM_Remoteevent_BAO_Session::getSessions($event2['id']));
+    $session2_1 = SessionFixture::addFixture($event2['id'], [
+      'title' => 'Event 2 Session 1',
+      'start_date' => '2026-04-18 12:00:00',
+      'end_date' => '2026-04-18 14:00:00',
+    ]);
+    CRM_Remoteevent_BAO_Session::cacheSessions([$event2['id']], []);
+    static::assertSame([
+      $session2_1['id'] => [
+        'id' => $session2_1['id'],
+        'event_id' => $event2['id'],
+        'title' => 'Event 2 Session 1',
+        'is_active' => TRUE,
+        'start_date' => '2026-04-18 12:00:00',
+        'end_date' => '2026-04-18 14:00:00',
+        'slot_id' => NULL,
+        'category_id' => NULL,
+        'type_id' => NULL,
+        'description' => NULL,
+        'max_participants' => 0,
+        'location' => NULL,
+        'presenter_id' => NULL,
+        'presenter_title' => NULL,
+        'day' => 2,
+      ],
+    ], CRM_Remoteevent_BAO_Session::getSessions($event2['id']));
+  }
+
+}

--- a/tests/phpunit/Civi/RemoteEvent/Fixtures/RemoteEventFixture.php
+++ b/tests/phpunit/Civi/RemoteEvent/Fixtures/RemoteEventFixture.php
@@ -28,7 +28,7 @@ final class RemoteEventFixture {
   /**
    * @phpstan-param array<string, mixed> $values
    *
-   * @phpstan-return array<string, mixed>
+   * @phpstan-return array{id: int, ...}
    *
    * @throws \CRM_Core_Exception
    */
@@ -63,6 +63,7 @@ final class RemoteEventFixture {
       $values['event_remote_registration.remote_registration_update_profiles'][] = $defaultUpdateProfile;
     }
 
+    // @phpstan-ignore return.type
     return Event::create(FALSE)
       ->setValues($values)
       ->execute()

--- a/tests/phpunit/Civi/RemoteEvent/Fixtures/SessionFixture.php
+++ b/tests/phpunit/Civi/RemoteEvent/Fixtures/SessionFixture.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright (C) 2026 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteEvent\Fixtures;
+
+use Civi\Api4\Session;
+
+final class SessionFixture {
+
+  /**
+   * @param int $eventId
+   * @param array<string, mixed> $values
+   *
+   * @return array{id: int, ...}
+   */
+  public static function addFixture(int $eventId, array $values = []): array {
+    $values += ['event_id' => $eventId];
+
+    // @phpstan-ignore return.type
+    return Session::create(FALSE)
+      ->setValues($values)
+      ->execute()
+      ->single();
+  }
+
+}


### PR DESCRIPTION
The `in_array()` test made a same comparison between an integerish string and integers in an array which is always `false`. The result was that the various participant session tokens for event messages were always empty. Now APIv4 is used to load sessions and integers aren't strings anymore.

systopia-reference: 32744